### PR TITLE
feat: 화면 하단에 내비게이션 바 추가 

### DIFF
--- a/app/src/main/java/com/example/myapplication/ExampleActivity.kt
+++ b/app/src/main/java/com/example/myapplication/ExampleActivity.kt
@@ -1,14 +1,47 @@
 package com.example.myapplication
 
 import android.os.Bundle
+import com.example.myapplication.R
 import com.example.myapplication.core.base.BaseActivity
+import com.example.myapplication.feature.future.FutureFragment
+import com.example.myapplication.feature.highlight.HighlightFragment
+import com.example.myapplication.feature.past.PastFragment
 import com.example.myapplication.feature.present.PresentFragment
+import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class ExampleActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // 테스트 목적: 항상 PresentFragment 를 붙여 화면 확인을 쉽게 합니다.
-        replaceFragment(PresentFragment())
+        setupBottomNavigation()
+        if (savedInstanceState == null) {
+            findViewById<BottomNavigationView>(R.id.bottomNavigation).selectedItemId =
+                R.id.navigation_present
+        }
+    }
+
+    private fun setupBottomNavigation() {
+        val bottomNavigation = findViewById<BottomNavigationView>(R.id.bottomNavigation)
+        bottomNavigation.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.navigation_past -> {
+                    replaceFragment(PastFragment(), tag = "past")
+                    true
+                }
+                R.id.navigation_present -> {
+                    replaceFragment(PresentFragment(), tag = "present")
+                    true
+                }
+                R.id.navigation_highlight -> {
+                    replaceFragment(HighlightFragment(), tag = "highlight")
+                    true
+                }
+                R.id.navigation_future -> {
+                    replaceFragment(FutureFragment(), tag = "future")
+                    true
+                }
+                else -> false
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/myapplication/feature/future/FutureFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/future/FutureFragment.kt
@@ -1,0 +1,24 @@
+package com.example.myapplication.feature.future
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.example.myapplication.R
+import com.example.myapplication.core.base.BaseFragment
+import com.example.myapplication.databinding.FragmentSimplePlaceholderBinding
+
+class FutureFragment : BaseFragment<FragmentSimplePlaceholderBinding>() {
+
+    override fun inflateBinding(
+        inflater: LayoutInflater,
+        container: ViewGroup?
+    ): FragmentSimplePlaceholderBinding {
+        return FragmentSimplePlaceholderBinding.inflate(inflater, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.placeholderText.setText(R.string.future_tab_placeholder)
+    }
+}

--- a/app/src/main/java/com/example/myapplication/feature/highlight/HighlightFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/highlight/HighlightFragment.kt
@@ -1,0 +1,24 @@
+package com.example.myapplication.feature.highlight
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.example.myapplication.R
+import com.example.myapplication.core.base.BaseFragment
+import com.example.myapplication.databinding.FragmentSimplePlaceholderBinding
+
+class HighlightFragment : BaseFragment<FragmentSimplePlaceholderBinding>() {
+
+    override fun inflateBinding(
+        inflater: LayoutInflater,
+        container: ViewGroup?
+    ): FragmentSimplePlaceholderBinding {
+        return FragmentSimplePlaceholderBinding.inflate(inflater, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.placeholderText.setText(R.string.highlight_tab_placeholder)
+    }
+}

--- a/app/src/main/java/com/example/myapplication/feature/past/PastFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/past/PastFragment.kt
@@ -1,0 +1,24 @@
+package com.example.myapplication.feature.past
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.example.myapplication.R
+import com.example.myapplication.core.base.BaseFragment
+import com.example.myapplication.databinding.FragmentSimplePlaceholderBinding
+
+class PastFragment : BaseFragment<FragmentSimplePlaceholderBinding>() {
+
+    override fun inflateBinding(
+        inflater: LayoutInflater,
+        container: ViewGroup?
+    ): FragmentSimplePlaceholderBinding {
+        return FragmentSimplePlaceholderBinding.inflate(inflater, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.placeholderText.setText(R.string.past_tab_placeholder)
+    }
+}

--- a/app/src/main/res/drawable/ic_baseline_history_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_history_24.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M13,3C8.03,3 4,7.03 4,12s4.03,9 9,9 9,-4.03 9,-9 -4.03,-9 -9,-9zM13,19c-3.86,0 -7,-3.14 -7,-7s3.14,-7 7,-7 7,3.14 7,7 -3.14,7 -7,7zM12.5,7H11v6l5.25,3.15 0.75,-1.23 -4.5,-2.67z" />
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_schedule_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_schedule_24.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8zM12.5,7H11v6l5,3 0.75,-1.23 -4.25,-2.52z" />
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_star_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_star_24.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z" />
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_today_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_today_24.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,3h-1V1h-2v2H8V1H6v2H5c-1.1,0 -1.99,0.9 -1.99,2L3,21c0,1.1 0.89,2 1.99,2H19c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2zM19,21H5V8h14v13zM7,10h5v5H7z" />
+</vector>

--- a/app/src/main/res/layout/activity_base.xml
+++ b/app/src/main/res/layout/activity_base.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/baseRoot"
     android:layout_width="match_parent"
@@ -13,7 +14,21 @@
     <FrameLayout
         android:id="@+id/container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/bottomNavigation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottomNavigation"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:labelVisibilityMode="labeled"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:menu="@menu/menu_bottom_navigation" />
 
     <!-- Simple full-screen loading overlay. Visibility controlled by BaseActivity.setLoadingVisibility -->
     <ProgressBar
@@ -21,8 +36,11 @@
         style="?android:attr/progressBarStyleLarge"
         android:layout_width="64dp"
         android:layout_height="64dp"
-        android:layout_gravity="center"
+        android:contentDescription="@string/loading"
         android:visibility="gone"
-        android:contentDescription="@string/loading" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-</FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_simple_placeholder.xml
+++ b/app/src/main/res/layout/fragment_simple_placeholder.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.example.myapplication.feature.past.PastFragment">
+
+    <TextView
+        android:id="@+id/placeholderText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceTitleMedium"
+        tools:text="과거 탭입니다"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_bottom_navigation.xml
+++ b/app/src/main/res/menu/menu_bottom_navigation.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/navigation_past"
+        android:icon="@drawable/ic_baseline_history_24"
+        android:title="@string/tab_past" />
+    <item
+        android:id="@+id/navigation_present"
+        android:icon="@drawable/ic_baseline_today_24"
+        android:title="@string/tab_present" />
+    <item
+        android:id="@+id/navigation_highlight"
+        android:icon="@drawable/ic_baseline_star_24"
+        android:title="@string/tab_highlight" />
+    <item
+        android:id="@+id/navigation_future"
+        android:icon="@drawable/ic_baseline_schedule_24"
+        android:title="@string/tab_future" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,11 @@
     <string name="no_input">입력된 메모가 없습니다.</string>
     <string name="saved">저장됨: %1$s</string>
     <string name="loading">loading</string>
+    <string name="tab_past">과거</string>
+    <string name="tab_present">현재</string>
+    <string name="tab_highlight">하이라이트</string>
+    <string name="tab_future">미래</string>
+    <string name="past_tab_placeholder">과거 탭입니다</string>
+    <string name="highlight_tab_placeholder">하이라이트 탭 (준비 중)</string>
+    <string name="future_tab_placeholder">미래 탭입니다</string>
 </resources>


### PR DESCRIPTION
### Motivation

- Provide a bottom navigation so the user can switch between Past / Present / Highlight / Future tabs using Material `BottomNavigationView`.
- Keep the existing `PresentFragment` behavior and layout unchanged while exposing separate Fragment units for other tabs for future implementation.
- Use a simple replace-only fragment swap to avoid growing the back stack and to keep navigation behavior predictable.
- Add minimal placeholder UI for tabs that are not yet implemented so users can clearly see tab changes.

### Description

- Added a `BottomNavigationView` to `activity_base.xml` and constrained the existing fragment container above it so fragments render above the nav bar.
- Created a bottom navigation menu `menu_bottom_navigation` with four items and added temporary vector icons in `res/drawable` and labels in `res/values/strings.xml`.
- Implemented three placeholder fragments `PastFragment`, `HighlightFragment`, and `FutureFragment` backed by a shared `fragment_simple_placeholder.xml` layout that displays a centered message, while `PresentFragment` was left unchanged.
- Updated `ExampleActivity` to initialize the bottom navigation, handle item selection by calling `replaceFragment(...)` for each tab, and set the default selected item to `navigation_present` on first launch.

### Testing

- No automated tests were run for this change.
- Manual verification steps performed: project files updated and compiled locally (no CI run reported).
- Navigation behavior uses `replaceFragment` so fragment transactions do not add to back stack and tab switching is immediate.
- No existing `PresentFragment` logic or layouts were modified during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963572517f0832e94ac7de74f1b94b6)