### PR TITLE
Add Flutter migration scaffold and initial Present/CreateMoment/Orientation screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@
 4. Choose an Android device/emulator and run `flutter run`.
 
 ### Migrated screens
-- Present home entry for the "현재" flow (photo-first entry point).
+- 과거 (Past) tab list UI (mocked memories).
+- 현재 (Present) tab entry for the photo-first flow.
+- 미래 (Future) tab planned memories UI (mocked plans).
 - "현재" record creation screen with photo selection and basic interactions.
 - Photo capture/gallery selection UI (mocked for now).
 - Main image selection with duplicate-selection messaging.
 - Photo orientation confirmation screen.
+- Bottom navigation with 과거 | 현재 | 미래 tabs.
 
 ### Known limitations
 - Backend/API and authentication are not wired yet (see TODOs in Dart code).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Chagok
+
+## Flutter migration (Android-first)
+
+### How to run in Android Studio
+1. Open the repository in Android Studio.
+2. Open the `chagok_flutter` directory as a Flutter module/project (Android Studio will detect it if the Flutter plugin is installed).
+3. Run `flutter pub get` from the `chagok_flutter` directory.
+4. Choose an Android device/emulator and run `flutter run`.
+
+### Migrated screens
+- Present home entry for the "현재" flow (photo-first entry point).
+- "현재" record creation screen with photo selection and basic interactions.
+- Photo capture/gallery selection UI (mocked for now).
+- Main image selection with duplicate-selection messaging.
+- Photo orientation confirmation screen.
+
+### Known limitations
+- Backend/API and authentication are not wired yet (see TODOs in Dart code).
+- Photo selection uses mocked placeholders instead of device gallery/camera integration.
+- State is local to widgets; no persistent storage yet.

--- a/chagok_flutter/.gitignore
+++ b/chagok_flutter/.gitignore
@@ -1,0 +1,15 @@
+# Flutter/Dart/Pub
+.dart_tool/
+.packages
+.pub/
+.pub-cache/
+build/
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# Platform specific
+android/.gradle/
+android/local.properties

--- a/chagok_flutter/analysis_options.yaml
+++ b/chagok_flutter/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: true

--- a/chagok_flutter/android/app/build.gradle
+++ b/chagok_flutter/android/app/build.gradle
@@ -1,0 +1,57 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+import java.util.Properties
+
+final Properties localProperties = new Properties()
+final File localPropertiesFile = rootProject.file('local.properties')
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withReader('UTF-8') { reader ->
+        localProperties.load(reader)
+    }
+}
+
+final String flutterRoot = localProperties.getProperty('flutter.sdk') ?: ''
+if (flutterRoot.isEmpty()) {
+    throw new GradleException("Flutter SDK not found. Define flutter.sdk in local.properties.")
+}
+
+apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+
+android {
+    namespace "com.example.chagok_flutter"
+    compileSdkVersion 34
+
+    defaultConfig {
+        applicationId "com.example.chagok_flutter"
+        minSdkVersion 21
+        targetSdkVersion 34
+        versionCode 1
+        versionName "0.1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
+    buildTypes {
+        release {
+            signingConfig signingConfigs.debug
+        }
+    }
+}
+
+flutter {
+    source '../..'
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
+}

--- a/chagok_flutter/android/app/src/main/AndroidManifest.xml
+++ b/chagok_flutter/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.chagok_flutter">
+
+    <application
+        android:label="Chagok"
+        android:name="${applicationName}"
+        android:icon="@android:drawable/sym_def_app_icon">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+            <meta-data
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
+    </application>
+
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/chagok_flutter/android/app/src/main/kotlin/com/example/chagok_flutter/MainActivity.kt
+++ b/chagok_flutter/android/app/src/main/kotlin/com/example/chagok_flutter/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.example.chagok_flutter
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()

--- a/chagok_flutter/android/app/src/main/res/drawable/launch_background.xml
+++ b/chagok_flutter/android/app/src/main/res/drawable/launch_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@android:color/white" />
+</layer-list>

--- a/chagok_flutter/android/app/src/main/res/values-night/styles.xml
+++ b/chagok_flutter/android/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="LaunchTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
+        <item name="android:windowBackground">@drawable/launch_background</item>
+    </style>
+
+    <style name="NormalTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
+        <item name="android:windowBackground">@android:color/black</item>
+    </style>
+</resources>

--- a/chagok_flutter/android/app/src/main/res/values/styles.xml
+++ b/chagok_flutter/android/app/src/main/res/values/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:windowBackground">@drawable/launch_background</item>
+    </style>
+
+    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:windowBackground">@android:color/white</item>
+    </style>
+</resources>

--- a/chagok_flutter/android/build.gradle
+++ b/chagok_flutter/android/build.gradle
@@ -1,0 +1,31 @@
+buildscript {
+    ext.kotlin_version = '1.9.22'
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.buildDir = '../build'
+subprojects {
+    project.buildDir = "${rootProject.buildDir}/${project.name}"
+}
+
+subprojects {
+    project.evaluationDependsOn(':app')
+}
+
+tasks.register("clean", Delete) {
+    delete rootProject.buildDir
+}

--- a/chagok_flutter/android/gradle.properties
+++ b/chagok_flutter/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/chagok_flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/chagok_flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/chagok_flutter/android/settings.gradle
+++ b/chagok_flutter/android/settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+include ':app'
+
+// Flutter tooling handles additional setup via the Flutter plugin in Android Studio.

--- a/chagok_flutter/lib/main.dart
+++ b/chagok_flutter/lib/main.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:chagok_flutter/screens/create_moment_screen.dart';
 import 'package:chagok_flutter/screens/photo_orientation_screen.dart';
-import 'package:chagok_flutter/screens/present_home_screen.dart';
-import 'package:chagok_flutter/screens/past_screen.dart';
-import 'package:chagok_flutter/screens/future_screen.dart';
 import 'package:chagok_flutter/theme/app_theme.dart';
+import 'package:chagok_flutter/widgets/main_navigation.dart';
 
 void main() {
   runApp(const ChagokApp());
@@ -18,7 +16,7 @@ class ChagokApp extends StatelessWidget {
     return MaterialApp(
       title: 'Chagok',
       theme: buildAppTheme(),
-      home: const HomeScaffold(),
+      home: const MainNavigation(),
       routes: {
         CreateMomentScreen.routeName: (_) => const CreateMomentScreen(),
       },
@@ -31,60 +29,6 @@ class ChagokApp extends StatelessWidget {
         }
         return null;
       },
-    );
-  }
-}
-
-class HomeScaffold extends StatefulWidget {
-  const HomeScaffold({super.key});
-
-  @override
-  State<HomeScaffold> createState() => _HomeScaffoldState();
-}
-
-class _HomeScaffoldState extends State<HomeScaffold> {
-  int _currentIndex = 1;
-
-  final List<Widget> _tabs = const [
-    PastScreen(),
-    PresentHomeScreen(),
-    FutureScreen(),
-  ];
-
-  void _onTabSelected(int index) {
-    setState(() {
-      _currentIndex = index;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: IndexedStack(
-        index: _currentIndex,
-        children: _tabs,
-      ),
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _currentIndex,
-        onTap: _onTabSelected,
-        selectedItemColor: AppColors.main,
-        unselectedItemColor: AppColors.textSecondary,
-        showUnselectedLabels: true,
-        items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.history_edu_outlined),
-            label: '과거',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.auto_awesome_outlined),
-            label: '현재',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.calendar_today_outlined),
-            label: '미래',
-          ),
-        ],
-      ),
     );
   }
 }

--- a/chagok_flutter/lib/main.dart
+++ b/chagok_flutter/lib/main.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:chagok_flutter/screens/create_moment_screen.dart';
+import 'package:chagok_flutter/screens/photo_orientation_screen.dart';
+import 'package:chagok_flutter/screens/present_home_screen.dart';
+import 'package:chagok_flutter/theme/app_theme.dart';
+
+void main() {
+  runApp(const ChagokApp());
+}
+
+class ChagokApp extends StatelessWidget {
+  const ChagokApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Chagok',
+      theme: buildAppTheme(),
+      initialRoute: PresentHomeScreen.routeName,
+      routes: {
+        PresentHomeScreen.routeName: (_) => const PresentHomeScreen(),
+        CreateMomentScreen.routeName: (_) => const CreateMomentScreen(),
+      },
+      onGenerateRoute: (settings) {
+        if (settings.name == PhotoOrientationScreen.routeName) {
+          final args = settings.arguments as PhotoOrientationArguments;
+          return MaterialPageRoute(
+            builder: (_) => PhotoOrientationScreen(arguments: args),
+          );
+        }
+        return null;
+      },
+    );
+  }
+}

--- a/chagok_flutter/lib/main.dart
+++ b/chagok_flutter/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:chagok_flutter/screens/create_moment_screen.dart';
 import 'package:chagok_flutter/screens/photo_orientation_screen.dart';
 import 'package:chagok_flutter/screens/present_home_screen.dart';
+import 'package:chagok_flutter/screens/past_screen.dart';
+import 'package:chagok_flutter/screens/future_screen.dart';
 import 'package:chagok_flutter/theme/app_theme.dart';
 
 void main() {
@@ -16,9 +18,8 @@ class ChagokApp extends StatelessWidget {
     return MaterialApp(
       title: 'Chagok',
       theme: buildAppTheme(),
-      initialRoute: PresentHomeScreen.routeName,
+      home: const HomeScaffold(),
       routes: {
-        PresentHomeScreen.routeName: (_) => const PresentHomeScreen(),
         CreateMomentScreen.routeName: (_) => const CreateMomentScreen(),
       },
       onGenerateRoute: (settings) {
@@ -30,6 +31,60 @@ class ChagokApp extends StatelessWidget {
         }
         return null;
       },
+    );
+  }
+}
+
+class HomeScaffold extends StatefulWidget {
+  const HomeScaffold({super.key});
+
+  @override
+  State<HomeScaffold> createState() => _HomeScaffoldState();
+}
+
+class _HomeScaffoldState extends State<HomeScaffold> {
+  int _currentIndex = 1;
+
+  final List<Widget> _tabs = const [
+    PastScreen(),
+    PresentHomeScreen(),
+    FutureScreen(),
+  ];
+
+  void _onTabSelected(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _currentIndex,
+        children: _tabs,
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: _onTabSelected,
+        selectedItemColor: AppColors.main,
+        unselectedItemColor: AppColors.textSecondary,
+        showUnselectedLabels: true,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.history_edu_outlined),
+            label: '과거',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.auto_awesome_outlined),
+            label: '현재',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.calendar_today_outlined),
+            label: '미래',
+          ),
+        ],
+      ),
     );
   }
 }

--- a/chagok_flutter/lib/screens/create_moment_screen.dart
+++ b/chagok_flutter/lib/screens/create_moment_screen.dart
@@ -1,0 +1,487 @@
+import 'package:flutter/material.dart';
+import 'package:chagok_flutter/screens/photo_orientation_screen.dart';
+import 'package:chagok_flutter/theme/app_theme.dart';
+
+class PhotoItem {
+  const PhotoItem({
+    required this.id,
+    required this.label,
+    required this.accent,
+    required this.source,
+  });
+
+  final String id;
+  final String label;
+  final Color accent;
+  final String source;
+}
+
+class CreateMomentScreen extends StatefulWidget {
+  const CreateMomentScreen({super.key});
+
+  static const String routeName = '/create';
+
+  @override
+  State<CreateMomentScreen> createState() => _CreateMomentScreenState();
+}
+
+class _CreateMomentScreenState extends State<CreateMomentScreen> {
+  final List<PhotoItem> _selectedPhotos = [];
+  final TextEditingController _memoController = TextEditingController();
+  PhotoItem? _mainPhoto;
+  bool _isFeatured = false;
+  int _score = 5;
+
+  final List<PhotoItem> _mockGallery = const [
+    PhotoItem(
+      id: 'gallery_1',
+      label: '빛이 스민 순간',
+      accent: Color(0xFFE3DFFD),
+      source: 'gallery',
+    ),
+    PhotoItem(
+      id: 'gallery_2',
+      label: '조용한 거리',
+      accent: Color(0xFFFDE2E4),
+      source: 'gallery',
+    ),
+    PhotoItem(
+      id: 'gallery_3',
+      label: '따뜻한 오후',
+      accent: Color(0xFFFFF1E6),
+      source: 'gallery',
+    ),
+  ];
+
+  @override
+  void dispose() {
+    _memoController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _openGallery() async {
+    final selected = await showModalBottomSheet<PhotoItem>(
+      context: context,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (context) {
+        return Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '갤러리에서 선택',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+              const SizedBox(height: 16),
+              ..._mockGallery.map(
+                (photo) => ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Container(
+                    width: 44,
+                    height: 44,
+                    decoration: BoxDecoration(
+                      color: photo.accent,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: const Icon(Icons.image_outlined, color: AppColors.main),
+                  ),
+                  title: Text(photo.label),
+                  subtitle: const Text('선택하면 방향을 확인해요'),
+                  onTap: () => Navigator.pop(context, photo),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (selected == null) return;
+
+    final confirmed = await _confirmOrientation(selected);
+    if (confirmed == null) return;
+
+    _addPhoto(confirmed);
+  }
+
+  Future<void> _openCamera() async {
+    final cameraPhoto = PhotoItem(
+      id: 'camera_${DateTime.now().millisecondsSinceEpoch}',
+      label: '카메라 스냅',
+      accent: AppColors.sub,
+      source: 'camera',
+    );
+
+    final confirmed = await _confirmOrientation(cameraPhoto);
+    if (confirmed == null) return;
+
+    _addPhoto(confirmed);
+  }
+
+  Future<PhotoItem?> _confirmOrientation(PhotoItem photo) async {
+    final result = await Navigator.pushNamed(
+      context,
+      PhotoOrientationScreen.routeName,
+      arguments: PhotoOrientationArguments(photo: photo),
+    );
+
+    if (result is PhotoItem) {
+      return result;
+    }
+
+    return null;
+  }
+
+  void _addPhoto(PhotoItem photo) {
+    setState(() {
+      _selectedPhotos.add(photo);
+      _mainPhoto ??= photo;
+    });
+  }
+
+  Future<void> _setAsMain(PhotoItem photo) async {
+    if (_mainPhoto?.id == photo.id) {
+      _showSnackBar('이미 대표 기억이 설정되어 있습니다.');
+      return;
+    }
+
+    if (_mainPhoto != null) {
+      final shouldReplace = await showDialog<bool>(
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: const Text('대표 기억 변경'),
+            content: const Text('이미 대표 기억이 설정되어 있습니다.\n현재 이미지를 대표 기억으로 변경하시겠습니까?'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('취소'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: const Text('변경'),
+              ),
+            ],
+          );
+        },
+      );
+
+      if (shouldReplace != true) {
+        return;
+      }
+    }
+
+    setState(() {
+      _mainPhoto = photo;
+    });
+  }
+
+  void _toggleFeatured(bool value) {
+    setState(() {
+      _isFeatured = value;
+    });
+  }
+
+  void _saveMoment() {
+    if (_selectedPhotos.isEmpty) {
+      _showSnackBar('사진을 선택해주세요.');
+      return;
+    }
+
+    // TODO: Integrate backend/API to persist the record.
+    _showSnackBar('임시로 저장되었습니다.');
+  }
+
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: const Text('순간 기록하기'),
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildPhotoCard(),
+                    const SizedBox(height: 16),
+                    _buildPhotoActions(),
+                    const SizedBox(height: 16),
+                    _buildSelectedPhotos(),
+                    const SizedBox(height: 24),
+                    CheckboxListTile(
+                      value: _isFeatured,
+                      onChanged: (value) => _toggleFeatured(value ?? false),
+                      title: const Text('대표 기억으로 설정'),
+                      subtitle: const Text('오늘을 대표할 기억으로 고정됩니다.'),
+                      controlAffinity: ListTileControlAffinity.leading,
+                      activeColor: AppColors.main,
+                    ),
+                    const SizedBox(height: 16),
+                    Text('이 순간을 한 줄로 남겨보세요',
+                        style: Theme.of(context).textTheme.bodyMedium),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: _memoController,
+                      maxLines: 2,
+                      decoration: InputDecoration(
+                        hintText: '짧은 메모를 작성해보세요…',
+                        filled: true,
+                        fillColor: Colors.white,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide(color: AppColors.border),
+                        ),
+                        enabledBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide(color: AppColors.border),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text('오늘의 점수',
+                            style: Theme.of(context).textTheme.bodyMedium),
+                        Text(
+                          '$_score',
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                color: AppColors.main,
+                                fontWeight: FontWeight.w700,
+                              ),
+                        ),
+                      ],
+                    ),
+                    Slider(
+                      value: _score.toDouble(),
+                      min: 1,
+                      max: 10,
+                      divisions: 9,
+                      activeColor: AppColors.main,
+                      onChanged: (value) {
+                        setState(() {
+                          _score = value.round();
+                        });
+                      },
+                    ),
+                    Text(
+                      '오늘의 만족도를 숫자로 남겨요.',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(20),
+              child: SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _saveMoment,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.main,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                  ),
+                  child: const Text('이 순간 저장하기'),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPhotoCard() {
+    return Container(
+      height: 240,
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: Container(
+              decoration: BoxDecoration(
+                color: _mainPhoto?.accent ?? AppColors.sub,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: _mainPhoto == null
+                  ? const Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.photo_camera, size: 40, color: AppColors.main),
+                          SizedBox(height: 8),
+                          Text('사진을 추가해주세요'),
+                        ],
+                      ),
+                    )
+                  : Center(
+                      child: Icon(
+                        Icons.photo,
+                        size: 64,
+                        color: AppColors.main.withOpacity(0.6),
+                      ),
+                    ),
+            ),
+          ),
+          if (_mainPhoto != null)
+            Positioned(
+              left: 16,
+              top: 16,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  '대표 기억',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPhotoActions() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        TextButton.icon(
+          onPressed: _openCamera,
+          icon: const Icon(Icons.camera_alt_outlined, color: AppColors.main),
+          label: const Text('카메라'),
+        ),
+        const SizedBox(width: 8),
+        TextButton.icon(
+          onPressed: _openGallery,
+          icon: const Icon(Icons.photo_library_outlined, color: AppColors.main),
+          label: const Text('갤러리'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSelectedPhotos() {
+    if (_selectedPhotos.isEmpty) {
+      return Text(
+        '선택된 사진이 아직 없어요.',
+        style: Theme.of(context).textTheme.bodySmall,
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '선택한 사진',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+        const SizedBox(height: 12),
+        SizedBox(
+          height: 110,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            itemCount: _selectedPhotos.length,
+            separatorBuilder: (_, __) => const SizedBox(width: 12),
+            itemBuilder: (context, index) {
+              final photo = _selectedPhotos[index];
+              final isMain = _mainPhoto?.id == photo.id;
+              return Container(
+                width: 140,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(
+                    color: isMain ? AppColors.main : AppColors.border,
+                    width: isMain ? 2 : 1,
+                  ),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      height: 44,
+                      decoration: BoxDecoration(
+                        color: photo.accent,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Center(
+                        child: Icon(Icons.photo, color: AppColors.main),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      photo.label,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      photo.source == 'camera' ? '카메라' : '갤러리',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const Spacer(),
+                    SizedBox(
+                      width: double.infinity,
+                      child: OutlinedButton(
+                        onPressed: () => _setAsMain(photo),
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: AppColors.main,
+                          side: BorderSide(color: AppColors.main),
+                          padding: const EdgeInsets.symmetric(vertical: 4),
+                        ),
+                        child: Text(isMain ? '대표 설정됨' : '대표로 지정'),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/chagok_flutter/lib/screens/future_screen.dart
+++ b/chagok_flutter/lib/screens/future_screen.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:chagok_flutter/theme/app_theme.dart';
+
+class FutureMemory {
+  const FutureMemory({
+    required this.id,
+    required this.title,
+    required this.date,
+    required this.detail,
+  });
+
+  final String id;
+  final String title;
+  final String date;
+  final String detail;
+}
+
+class FutureScreen extends StatelessWidget {
+  const FutureScreen({super.key});
+
+  static const List<FutureMemory> _mockPlans = [
+    FutureMemory(
+      id: 'future_1',
+      title: '바닷가 일몰 기록',
+      date: '2024.09.12',
+      detail: '파도 소리를 담아두기',
+    ),
+    FutureMemory(
+      id: 'future_2',
+      title: '친구와 사진 산책',
+      date: '2024.10.04',
+      detail: '서로의 순간을 기록하기',
+    ),
+    FutureMemory(
+      id: 'future_3',
+      title: '전시회 방문',
+      date: '2024.10.18',
+      detail: '작품 앞에서 느낀 감정 적기',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '미래의 계획',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '다가올 기억을 차곡차곡 모아봐요.',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: AppColors.textSecondary),
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: ListView.separated(
+                itemCount: _mockPlans.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 12),
+                itemBuilder: (context, index) {
+                  final plan = _mockPlans[index];
+                  return Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(18),
+                      border: Border.all(color: AppColors.border),
+                    ),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 56,
+                          height: 56,
+                          decoration: BoxDecoration(
+                            color: AppColors.sub,
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: const Icon(
+                            Icons.event_available_outlined,
+                            color: AppColors.main,
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                plan.title,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodyMedium
+                                    ?.copyWith(fontWeight: FontWeight.w600),
+                              ),
+                              const SizedBox(height: 6),
+                              Text(
+                                plan.detail,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodySmall
+                                    ?.copyWith(color: AppColors.textSecondary),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(
+                              plan.date,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(color: AppColors.main),
+                            ),
+                            const SizedBox(height: 8),
+                            const Icon(
+                              Icons.chevron_right,
+                              color: AppColors.textSecondary,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'TODO: 미래 계획은 백엔드/로컬 저장소 연동 후 불러옵니다.',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: AppColors.textSecondary),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/chagok_flutter/lib/screens/past_screen.dart
+++ b/chagok_flutter/lib/screens/past_screen.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:chagok_flutter/theme/app_theme.dart';
+
+class PastMemory {
+  const PastMemory({
+    required this.id,
+    required this.title,
+    required this.subtitle,
+    required this.emotion,
+  });
+
+  final String id;
+  final String title;
+  final String subtitle;
+  final String emotion;
+}
+
+class PastScreen extends StatelessWidget {
+  const PastScreen({super.key});
+
+  static const List<PastMemory> _mockMemories = [
+    PastMemory(
+      id: 'past_1',
+      title: '따뜻한 오후의 산책',
+      subtitle: '햇살이 유난히 부드러웠던 날',
+      emotion: '잔잔함',
+    ),
+    PastMemory(
+      id: 'past_2',
+      title: '카페 창가 자리',
+      subtitle: '작은 메모와 커피 향',
+      emotion: '안정감',
+    ),
+    PastMemory(
+      id: 'past_3',
+      title: '비가 내린 저녁',
+      subtitle: '우산 아래서 웃던 순간',
+      emotion: '설렘',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '과거의 기록',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '지나간 순간을 조용히 다시 바라봐요.',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: AppColors.textSecondary),
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: ListView.separated(
+                itemCount: _mockMemories.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 12),
+                itemBuilder: (context, index) {
+                  final memory = _mockMemories[index];
+                  return Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(18),
+                      border: Border.all(color: AppColors.border),
+                    ),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 56,
+                          height: 56,
+                          decoration: BoxDecoration(
+                            color: AppColors.sub,
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: const Icon(
+                            Icons.photo_outlined,
+                            color: AppColors.main,
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                memory.title,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodyMedium
+                                    ?.copyWith(fontWeight: FontWeight.w600),
+                              ),
+                              const SizedBox(height: 6),
+                              Text(
+                                memory.subtitle,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodySmall
+                                    ?.copyWith(color: AppColors.textSecondary),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(
+                              memory.emotion,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(color: AppColors.main),
+                            ),
+                            const SizedBox(height: 8),
+                            const Icon(
+                              Icons.chevron_right,
+                              color: AppColors.textSecondary,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'TODO: 과거 기록은 백엔드/로컬 저장소 연동 후 불러옵니다.',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: AppColors.textSecondary),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/chagok_flutter/lib/screens/photo_orientation_screen.dart
+++ b/chagok_flutter/lib/screens/photo_orientation_screen.dart
@@ -1,0 +1,131 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:chagok_flutter/screens/create_moment_screen.dart';
+import 'package:chagok_flutter/theme/app_theme.dart';
+
+class PhotoOrientationArguments {
+  const PhotoOrientationArguments({required this.photo});
+
+  final PhotoItem photo;
+}
+
+class PhotoOrientationScreen extends StatefulWidget {
+  const PhotoOrientationScreen({super.key, required this.arguments});
+
+  static const String routeName = '/orientation';
+
+  final PhotoOrientationArguments arguments;
+
+  @override
+  State<PhotoOrientationScreen> createState() => _PhotoOrientationScreenState();
+}
+
+class _PhotoOrientationScreenState extends State<PhotoOrientationScreen> {
+  double _rotationTurns = 0;
+
+  void _rotate() {
+    setState(() {
+      _rotationTurns = (_rotationTurns + 0.25) % 1;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final photo = widget.arguments.photo;
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '사진 방향을 확인해주세요',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '원하는 방향으로 맞춘 뒤 저장해요.',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 24),
+              Expanded(
+                child: Container(
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(24),
+                    border: Border.all(color: AppColors.border),
+                  ),
+                  child: Center(
+                    child: Transform.rotate(
+                      angle: _rotationTurns * 2 * math.pi,
+                      child: Container(
+                        width: 180,
+                        height: 180,
+                        decoration: BoxDecoration(
+                          color: photo.accent,
+                          borderRadius: BorderRadius.circular(24),
+                        ),
+                        child: const Icon(
+                          Icons.photo,
+                          size: 72,
+                          color: AppColors.main,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: _rotate,
+                  icon: const Icon(Icons.rotate_right),
+                  label: const Text('90° 회전'),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextButton(
+                      onPressed: () => Navigator.pop(context),
+                      child: const Text('다시 선택'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () => Navigator.pop(context, photo),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.main,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(14),
+                        ),
+                      ),
+                      child: const Text('이 방향으로 저장'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/chagok_flutter/lib/screens/present_home_screen.dart
+++ b/chagok_flutter/lib/screens/present_home_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:chagok_flutter/screens/create_moment_screen.dart';
+import 'package:chagok_flutter/theme/app_theme.dart';
+
+class PresentHomeScreen extends StatelessWidget {
+  const PresentHomeScreen({super.key});
+
+  static const String routeName = '/';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '안녕하세요',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '오늘의 순간을 부드럽게 기록해요.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+              ),
+              const SizedBox(height: 24),
+              Expanded(
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(20),
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(24),
+                    border: Border.all(color: AppColors.border),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '사진으로 시작되는 기록',
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: Container(
+                          width: double.infinity,
+                          decoration: BoxDecoration(
+                            color: AppColors.sub,
+                            borderRadius: BorderRadius.circular(18),
+                          ),
+                          child: const Center(
+                            child: Icon(
+                              Icons.photo_outlined,
+                              size: 72,
+                              color: AppColors.main,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          onPressed: () {
+                            Navigator.pushNamed(
+                              context,
+                              CreateMomentScreen.routeName,
+                            );
+                          },
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: AppColors.main,
+                            foregroundColor: Colors.white,
+                            padding: const EdgeInsets.symmetric(vertical: 14),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(14),
+                            ),
+                          ),
+                          child: const Text('순간 기록하기'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/chagok_flutter/lib/theme/app_theme.dart
+++ b/chagok_flutter/lib/theme/app_theme.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  static const Color main = Color(0xFF5B5FEF);
+  static const Color sub = Color(0xFFF4F1FF);
+  static const Color textPrimary = Color(0xFF1B1B1F);
+  static const Color textSecondary = Color(0xFF6F6F7A);
+  static const Color border = Color(0xFFE3E0F5);
+}
+
+ThemeData buildAppTheme() {
+  return ThemeData(
+    useMaterial3: true,
+    colorScheme: const ColorScheme.light(
+      primary: AppColors.main,
+      secondary: AppColors.main,
+      surface: Colors.white,
+      onPrimary: Colors.white,
+      onSecondary: Colors.white,
+      onSurface: AppColors.textPrimary,
+    ),
+    scaffoldBackgroundColor: AppColors.sub,
+    textTheme: const TextTheme(
+      headlineSmall: TextStyle(
+        fontSize: 24,
+        fontWeight: FontWeight.w600,
+        color: AppColors.textPrimary,
+      ),
+      bodyMedium: TextStyle(
+        fontSize: 14,
+        color: AppColors.textPrimary,
+      ),
+      bodySmall: TextStyle(
+        fontSize: 12,
+        color: AppColors.textSecondary,
+      ),
+    ),
+    snackBarTheme: const SnackBarThemeData(
+      backgroundColor: AppColors.main,
+      contentTextStyle: TextStyle(color: Colors.white),
+    ),
+  );
+}

--- a/chagok_flutter/lib/widgets/main_navigation.dart
+++ b/chagok_flutter/lib/widgets/main_navigation.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:chagok_flutter/screens/future_screen.dart';
+import 'package:chagok_flutter/screens/past_screen.dart';
+import 'package:chagok_flutter/screens/present_home_screen.dart';
+import 'package:chagok_flutter/theme/app_theme.dart';
+
+class MainNavigation extends StatefulWidget {
+  const MainNavigation({super.key});
+
+  @override
+  State<MainNavigation> createState() => _MainNavigationState();
+}
+
+class _MainNavigationState extends State<MainNavigation> {
+  int _currentIndex = 1;
+
+  final List<Widget> _tabs = const [
+    PastScreen(),
+    PresentHomeScreen(),
+    FutureScreen(),
+  ];
+
+  void _onTabSelected(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _currentIndex,
+        children: _tabs,
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: _onTabSelected,
+        selectedItemColor: AppColors.main,
+        unselectedItemColor: AppColors.textSecondary,
+        showUnselectedLabels: true,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.history_edu_outlined),
+            label: '과거',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.auto_awesome_outlined),
+            label: '현재',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.calendar_today_outlined),
+            label: '미래',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/chagok_flutter/pubspec.yaml
+++ b/chagok_flutter/pubspec.yaml
@@ -1,0 +1,20 @@
+name: chagok_flutter
+description: Flutter migration for the Chagok Android app.
+version: 0.1.0
+publish_to: "none"
+
+environment:
+  sdk: ">=3.3.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+
+flutter:
+  uses-material-design: true

--- a/chagok_flutter/test/widget_test.dart
+++ b/chagok_flutter/test/widget_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chagok_flutter/main.dart';
+
+void main() {
+  testWidgets('App smoke test', (tester) async {
+    await tester.pumpWidget(const ChagokApp());
+    expect(find.text('순간 기록하기'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
### Motivation
- Start migrating the Android app UI (Kotlin/XML) to Flutter while keeping the original code untouched on the main branch. 
- Provide an initial photo-first flow for the "현재" feature including screen structure, navigation and basic interactions. 
- Keep the migration minimal and incremental, deferring backend/auth and persistent storage to future work. 

### Description
- Add a new Flutter module at `chagok_flutter` with project files, Android host config, and Gradle wrappers to allow opening as a Flutter project. 
- Implement `PresentHomeScreen`, `CreateMomentScreen`, and `PhotoOrientationScreen` with a simple `AppColors` theme and navigation wired via `main.dart`. 
- Provide mocked camera/gallery interactions, photo selection list, main-image selection logic with duplicate-selection messaging, orientation confirmation, and TODOs where backend integration is expected. 
- Add a README with run instructions and known limitations and include a smoke widget test at `chagok_flutter/test/widget_test.dart`.

### Testing
- No automated Flutter tests were executed because the Flutter SDK is not available in the environment (`flutter --version` returned an error). 
- A smoke widget test was added at `chagok_flutter/test/widget_test.dart` for local verification once the Flutter SDK is available. 
- Manual local run instructions are documented in `README.md` (run `flutter pub get` and `flutter run` from the `chagok_flutter` directory). 
- Basic repository commit was created on branch `feature/flutter-migration` with the new files committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a84b09c0832e95962afc56a013b9)