### PR TITLE
Add CES scoring inputs to present record

### DIFF
--- a/app/src/main/java/com/example/myapplication/core/util/TimeState.kt
+++ b/app/src/main/java/com/example/myapplication/core/util/TimeState.kt
@@ -1,0 +1,7 @@
+package com.example.myapplication.core.util
+
+enum class TimeState {
+    PAST,
+    PRESENT,
+    FUTURE
+}

--- a/app/src/main/java/com/example/myapplication/data/present/DailyModels.kt
+++ b/app/src/main/java/com/example/myapplication/data/present/DailyModels.kt
@@ -1,0 +1,43 @@
+package com.example.myapplication.data.present
+
+// 파일명: DailyModels.kt
+
+/**
+ * 하루의 기록을 담는 데이터 모델
+ */
+data class DailyRecord(
+    val id: String,
+    val photoUri: String,
+    val memo: String,
+    val score: Int,
+    val cesMetrics: CesMetrics,
+    val meaning: Meaning,
+    val date: String,
+    val isFeatured: Boolean
+)
+
+/**
+ * CES 지수 (정체성, 연결성, 관점 + 가중치 점수)
+ */
+data class CesMetrics(
+    val identity: Int,
+    val connectivity: Int,
+    val perspective: Int,
+    val weightedScore: Float
+)
+
+/**
+ * 의미 부여 (기억하기 / 잊기)
+ */
+enum class Meaning {
+    REMEMBER, FORGET
+}
+
+/**
+ * 입력용 임시 데이터 (ViewModel용)
+ */
+data class CesInput(
+    val identity: Int = 1,
+    val connectivity: Int = 1,
+    val perspective: Int = 1
+)

--- a/app/src/main/java/com/example/myapplication/feature/present/CesModels.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/CesModels.kt
@@ -1,0 +1,24 @@
+package com.example.myapplication.feature.present
+
+data class CesInput(
+    val identity: Int = 3,
+    val connectivity: Int = 3,
+    val perspective: Int = 3
+)
+
+data class CesMetrics(
+    val identity: Int,
+    val connectivity: Int,
+    val perspective: Int,
+    val weightedScore: Float
+)
+
+interface CesOutlierAnalyzer {
+    fun analyze(records: List<DailyRecord>): CesOutlierResult
+}
+
+data class CesOutlierResult(
+    val identityOutliers: List<DailyRecord> = emptyList(),
+    val connectivityOutliers: List<DailyRecord> = emptyList(),
+    val perspectiveOutliers: List<DailyRecord> = emptyList()
+)

--- a/app/src/main/java/com/example/myapplication/feature/present/CreateMomentFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/CreateMomentFragment.kt
@@ -93,9 +93,9 @@ class CreateMomentFragment : BaseFragment<FragmentCreateMomentBinding>() {
         super.onViewCreated(view, savedInstanceState)
 
         setupToolbar()
-        setupSlider()
         setupPhotoButtons()
         setupMemoInput()
+        setupCesInputs()
         setupFeaturedCheckbox()
         setupSaveButton()
         observeUiState()
@@ -107,20 +107,6 @@ class CreateMomentFragment : BaseFragment<FragmentCreateMomentBinding>() {
         binding.toolbar.setNavigationOnClickListener {
             parentFragmentManager.popBackStack()
         }
-    }
-
-    private fun setupSlider() {
-        binding.scoreSlider.valueFrom = 1f
-        binding.scoreSlider.valueTo = 10f
-
-        binding.scoreSlider.addOnChangeListener { _, value, _ ->
-            val score = value.toInt()
-            binding.scoreValue.text = score.toString()
-            viewModel.setScore(score)
-        }
-
-        binding.scoreSlider.value = viewModel.uiState.value.score.toFloat()
-        binding.scoreValue.text = viewModel.uiState.value.score.toString()
     }
 
     private fun setupPhotoButtons() {
@@ -146,6 +132,35 @@ class CreateMomentFragment : BaseFragment<FragmentCreateMomentBinding>() {
                 viewModel.setMemo(s.toString())
             }
         })
+    }
+
+    private fun setupCesInputs() {
+        binding.identitySlider.valueFrom = 1f
+        binding.identitySlider.valueTo = 5f
+        binding.identitySlider.stepSize = 1f
+
+        binding.connectivitySlider.valueFrom = 1f
+        binding.connectivitySlider.valueTo = 5f
+        binding.connectivitySlider.stepSize = 1f
+
+        binding.perspectiveSlider.valueFrom = 1f
+        binding.perspectiveSlider.valueTo = 5f
+        binding.perspectiveSlider.stepSize = 1f
+
+        binding.identitySlider.addOnChangeListener { _, value, _ ->
+            viewModel.setCesIdentity(value.toInt())
+        }
+        binding.connectivitySlider.addOnChangeListener { _, value, _ ->
+            viewModel.setCesConnectivity(value.toInt())
+        }
+        binding.perspectiveSlider.addOnChangeListener { _, value, _ ->
+            viewModel.setCesPerspective(value.toInt())
+        }
+
+        val state = viewModel.uiState.value
+        binding.identitySlider.value = state.cesInput.identity.toFloat()
+        binding.connectivitySlider.value = state.cesInput.connectivity.toFloat()
+        binding.perspectiveSlider.value = state.cesInput.perspective.toFloat()
     }
 
     private fun setupFeaturedCheckbox() {
@@ -274,6 +289,27 @@ class CreateMomentFragment : BaseFragment<FragmentCreateMomentBinding>() {
                         viewModel.resetSavedState()
                         parentFragmentManager.popBackStack()
                     }
+
+                    binding.identityValue.text = state.cesInput.identity.toString()
+                    binding.connectivityValue.text = state.cesInput.connectivity.toString()
+                    binding.perspectiveValue.text = state.cesInput.perspective.toString()
+                    binding.cesScoreValue.text = state.cesWeightedScore.toString()
+                    binding.cesScoreDescription.text = state.cesDescription
+
+                    if (binding.identitySlider.value.toInt() != state.cesInput.identity) {
+                        binding.identitySlider.value = state.cesInput.identity.toFloat()
+                    }
+                    if (binding.connectivitySlider.value.toInt() != state.cesInput.connectivity) {
+                        binding.connectivitySlider.value = state.cesInput.connectivity.toFloat()
+                    }
+                    if (binding.perspectiveSlider.value.toInt() != state.cesInput.perspective) {
+                        binding.perspectiveSlider.value = state.cesInput.perspective.toFloat()
+                    }
+
+                    val cesEditable = state.timeState == com.example.myapplication.core.util.TimeState.PRESENT
+                    binding.identitySlider.isEnabled = cesEditable
+                    binding.connectivitySlider.isEnabled = cesEditable
+                    binding.perspectiveSlider.isEnabled = cesEditable
                 }
             }
         }

--- a/app/src/main/java/com/example/myapplication/feature/present/CreateMomentUiState.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/CreateMomentUiState.kt
@@ -7,7 +7,6 @@ package com.example.myapplication.feature.present
  *
  * @param selectedPhotoUri 사용자가 선택한 사진 URI (null이면 선택 안 됨)
  * @param memo 한 줄 메모 입력값
- * @param score 점수 (1~10)
  * @param meaning 기억 or 잊기
  * @param isFeatured 오늘의 대표 기억 체크 여부
  * @param showFeaturedConflictDialog 대표 기억 중복 선택 안내 다이얼로그 노출 여부
@@ -18,7 +17,10 @@ package com.example.myapplication.feature.present
 data class CreateMomentUiState(
     val selectedPhotoUri: String? = null,
     val memo: String = "",
-    val score: Int = 5, // 기본값: 중간값
+    val cesInput: CesInput = CesInput(),
+    val cesWeightedScore: Float = 3.0f,
+    val cesDescription: String = "보통",
+    val timeState: com.example.myapplication.core.util.TimeState = com.example.myapplication.core.util.TimeState.PRESENT,
     val meaning: Meaning = Meaning.REMEMBER,
     val isFeatured: Boolean = false,
     val showFeaturedConflictDialog: Boolean = false,

--- a/app/src/main/java/com/example/myapplication/feature/present/CreateMomentViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/CreateMomentViewModel.kt
@@ -3,6 +3,7 @@ package com.example.myapplication.feature.present
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.myapplication.core.util.TimeState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,7 +17,7 @@ import java.util.*
  *
  * 순간 기록 화면(CreateMomentFragment)의 상태와 로직을 관리합니다.
  * - 사진 선택/촬영 결과 처리
- * - 메모, 점수, 기억/잊기 상태 관리
+     * - 메모, 기억/잊기 상태 관리
  * - 저장 로직 실행
  *
  * 주의: 현재는 in-memory 저장만 지원합니다 (Room DB는 추후 추가)
@@ -56,9 +57,32 @@ class CreateMomentViewModel : ViewModel() {
     /**
      * 점수 슬라이더 값 업데이트 (1~10)
      */
-    fun setScore(score: Int) {
-        val validScore = score.coerceIn(1, 10)
-        _uiState.update { it.copy(score = validScore) }
+    fun setTimeState(state: TimeState) {
+        _uiState.update { it.copy(timeState = state) }
+    }
+
+    fun setCesIdentity(value: Int) {
+        if (!isPresentState()) {
+            _uiState.update { it.copy(errorMessage = "과거 기록은 수정할 수 없습니다") }
+            return
+        }
+        updateCesInput { it.copy(identity = value.coerceIn(1, 5)) }
+    }
+
+    fun setCesConnectivity(value: Int) {
+        if (!isPresentState()) {
+            _uiState.update { it.copy(errorMessage = "과거 기록은 수정할 수 없습니다") }
+            return
+        }
+        updateCesInput { it.copy(connectivity = value.coerceIn(1, 5)) }
+    }
+
+    fun setCesPerspective(value: Int) {
+        if (!isPresentState()) {
+            _uiState.update { it.copy(errorMessage = "과거 기록은 수정할 수 없습니다") }
+            return
+        }
+        updateCesInput { it.copy(perspective = value.coerceIn(1, 5)) }
     }
 
     /**
@@ -81,8 +105,7 @@ class CreateMomentViewModel : ViewModel() {
      * 요구사항:
      * 1. 사진은 필수 (selectedPhotoUri가 null이면 실패)
      * 2. 메모는 선택사항 (빈 값 허용)
-     * 3. 점수는 1~10
-     * 4. 기억/잊기 선택은 필수
+     * 3. 기억/잊기 선택은 필수
      *
      * 저장 완료 시 savedSuccessfully = true로 설정
      * (호출자는 이 값을 감지하여 PresentFragment로 복귀)
@@ -90,14 +113,14 @@ class CreateMomentViewModel : ViewModel() {
     fun saveMoment() {
         val currentState = _uiState.value
 
-        // 유효성 검사
-        if (currentState.selectedPhotoUri.isNullOrBlank()) {
-            _uiState.update { it.copy(errorMessage = "사진을 선택해주세요") }
+        if (!isPresentState()) {
+            _uiState.update { it.copy(errorMessage = "과거 기록은 수정할 수 없습니다") }
             return
         }
 
-        if (currentState.score < 1 || currentState.score > 10) {
-            _uiState.update { it.copy(errorMessage = "점수는 1~10 사이여야 합니다") }
+        // 유효성 검사
+        if (currentState.selectedPhotoUri.isNullOrBlank()) {
+            _uiState.update { it.copy(errorMessage = "사진을 선택해주세요") }
             return
         }
 
@@ -129,7 +152,8 @@ class CreateMomentViewModel : ViewModel() {
                     id = UUID.randomUUID().toString(),
                     photoUri = currentState.selectedPhotoUri ?: "",
                     memo = currentState.memo,
-                    score = currentState.score,
+                    score = DEFAULT_SCORE,
+                    cesMetrics = buildCesMetrics(currentState.cesInput),
                     meaning = currentState.meaning,
                     date = today,
                     isFeatured = currentState.isFeatured
@@ -209,7 +233,47 @@ class CreateMomentViewModel : ViewModel() {
         }
     }
 
+    private fun updateCesInput(transform: (CesInput) -> CesInput) {
+        _uiState.update { state ->
+            val updatedInput = transform(state.cesInput)
+            val weightedScore = calculateCesScore(updatedInput)
+            val description = describeCesScore(weightedScore)
+            state.copy(
+                cesInput = updatedInput,
+                cesWeightedScore = weightedScore,
+                cesDescription = description
+            )
+        }
+    }
+
+    private fun calculateCesScore(input: CesInput): Float {
+        val weightedScore = (0.5f * input.identity) +
+            (0.2f * input.connectivity) +
+            (0.3f * input.perspective)
+        return (weightedScore * 10f).toInt() / 10f
+    }
+
+    private fun describeCesScore(score: Float): String {
+        return when {
+            score <= 2.0f -> "낮음"
+            score <= 3.5f -> "보통"
+            else -> "높음"
+        }
+    }
+
+    private fun buildCesMetrics(input: CesInput): CesMetrics {
+        return CesMetrics(
+            identity = input.identity,
+            connectivity = input.connectivity,
+            perspective = input.perspective,
+            weightedScore = calculateCesScore(input)
+        )
+    }
+
+    private fun isPresentState(): Boolean = _uiState.value.timeState == TimeState.PRESENT
+
+    companion object {
+        private const val DEFAULT_SCORE = 5
+    }
+
 }
-
-
-

--- a/app/src/main/java/com/example/myapplication/feature/present/CreateMomentViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/CreateMomentViewModel.kt
@@ -30,11 +30,14 @@ class CreateMomentViewModel : ViewModel() {
     // 저장된 기록을 임시로 메모리에 보관 (싱글톤으로 변경 가능)
     companion object {
         private val savedRecords = mutableListOf<DailyRecord>()
+        private const val DEFAULT_SCORE = 5
 
         fun getSavedRecords(): List<DailyRecord> = savedRecords.toList()
+
         fun addRecord(record: DailyRecord) {
             savedRecords.add(record)
         }
+
         fun clearRecords() {
             savedRecords.clear()
         }
@@ -272,8 +275,5 @@ class CreateMomentViewModel : ViewModel() {
 
     private fun isPresentState(): Boolean = _uiState.value.timeState == TimeState.PRESENT
 
-    companion object {
-        private const val DEFAULT_SCORE = 5
-    }
 
 }

--- a/app/src/main/java/com/example/myapplication/feature/present/MomentAdapter.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/MomentAdapter.kt
@@ -1,0 +1,55 @@
+package com.example.myapplication.feature.present
+
+import android.net.Uri
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.myapplication.databinding.ItemMomentCardBinding
+
+// ❌ 삭제됨: data class DailyRecord(...)
+// (이제 DailyModels.kt에 있는 클래스를 자동으로 가져다 씁니다)
+
+class MomentAdapter(
+    private var items: List<DailyRecord> = emptyList()
+) : RecyclerView.Adapter<MomentAdapter.MomentViewHolder>() {
+
+    inner class MomentViewHolder(private val binding: ItemMomentCardBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(record: DailyRecord) {
+            // 1. 이미지 로드
+            if (record.photoUri.isNotEmpty()) {
+                binding.ivMomentPhoto.setImageURI(Uri.parse(record.photoUri))
+            } else {
+                // 이미지가 없을 경우 처리 (필요시 구현)
+                binding.ivMomentPhoto.setImageDrawable(null)
+            }
+
+            // 2. 점수 설정 (수정됨: cesMetrics 안에 있는 weightedScore 사용)
+            binding.tvCesScore.text = record.cesMetrics.weightedScore.toString()
+
+            // 3. 메모 설정
+            binding.tvMemo.text = if (record.memo.isNotBlank()) record.memo else "메모가 없습니다."
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MomentViewHolder {
+        val binding = ItemMomentCardBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return MomentViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: MomentViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun submitList(newItems: List<DailyRecord>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/java/com/example/myapplication/feature/present/PresentFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/PresentFragment.kt
@@ -42,18 +42,7 @@ class PresentFragment : BaseFragment<FragmentPresentBinding>() {
         binding.addRecordIcon.visibility = View.VISIBLE
 
         // CreateMomentFragment에서 돌아올 때 데이터 갱신
-        refreshRecordsList()
-    }
-
-    private fun refreshRecordsList() {
-        // CreateMomentViewModel에서 저장된 기록들을 다시 로드하여 RecordAdapter 갱신
-        val savedRecords = CreateMomentViewModel.getSavedRecords()
-        if (savedRecords.isNotEmpty()) {
-            binding.emptyRecordCard.visibility = View.GONE
-            binding.recordsCarousel.visibility = View.VISIBLE
-            binding.recordsIndicator.visibility = View.VISIBLE
-            recordAdapter.submitList(savedRecords.toList())
-        }
+        viewModel.loadPresentData()
     }
 
     private fun setupRecyclerViews() {

--- a/app/src/main/java/com/example/myapplication/feature/present/PresentFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/PresentFragment.kt
@@ -14,12 +14,16 @@ import com.example.myapplication.core.base.BaseFragment
 import com.example.myapplication.databinding.FragmentPresentBinding
 import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.coroutines.launch
+import kotlin.collections.reversed
 
 class PresentFragment : BaseFragment<FragmentPresentBinding>() {
 
+    // PresentViewModel은 기존대로 유지 (Practice 관련 데이터 관리)
     private val viewModel: PresentViewModel by activityViewModels { PresentViewModelFactory() }
+
+    // 어댑터 정의
     private lateinit var practiceAdapter: PracticeAdapter
-    private lateinit var recordAdapter: RecordAdapter
+    private lateinit var momentAdapter: MomentAdapter // RecordAdapter -> MomentAdapter로 변경
 
     override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentPresentBinding {
         return FragmentPresentBinding.inflate(inflater, container, false)
@@ -37,38 +41,80 @@ class PresentFragment : BaseFragment<FragmentPresentBinding>() {
 
     override fun onResume() {
         super.onResume()
-        // Fragment가 다시 보일 때마다 버튼 보이기
-        binding.createMomentButton.visibility = View.VISIBLE
-        binding.addRecordIcon.visibility = View.VISIBLE
+        // 화면이 다시 보일 때마다 UI 상태 갱신 (저장하고 돌아왔을 때 반영)
+        refreshData()
+    }
 
-        // CreateMomentFragment에서 돌아올 때 데이터 갱신
+    private fun refreshData() {
+        // 1. Practice 데이터 갱신 (ViewModel)
         viewModel.loadPresentData()
+
+        // 2. Record 데이터 갱신 (CreateMomentViewModel의 Static 데이터 사용)
+        // 주의: 실제 앱에서는 Room DB나 서버 데이터를 PresentViewModel에서 불러오는 것이 좋습니다.
+        val savedRecords = CreateMomentViewModel.getSavedRecords()
+        updateRecordUi(savedRecords)
     }
 
     private fun setupRecyclerViews() {
+        // 1. Practice RecyclerView (기존 유지)
         practiceAdapter = PracticeAdapter { practice, isAchieved ->
             viewModel.onPracticeStateChanged(practice.id, isAchieved)
         }
         binding.practicesRecyclerView.adapter = practiceAdapter
 
-        recordAdapter = RecordAdapter()
-        binding.recordsCarousel.adapter = recordAdapter
+        // 2. Moment Carousel (ViewPager2) - 변경됨
+        momentAdapter = MomentAdapter()
+        binding.recordsCarousel.apply {
+            adapter = momentAdapter
+            offscreenPageLimit = 1 // 양옆의 카드를 미리 로드하여 부드럽게
+            // (선택사항) 양옆 카드 살짝 보이게 하려면 padding과 clipToPadding 설정이 XML에 있어야 함
+        }
 
-        // Link the TabLayout and ViewPager2 for the indicator
+        // 3. Indicator 연결 (TabLayout + ViewPager2)
         TabLayoutMediator(binding.recordsIndicator, binding.recordsCarousel) { tab, position ->
-            // No-op, we only need the dots
+            // 탭 텍스트 없이 점만 표시
         }.attach()
     }
 
     private fun setupClickListeners() {
+        // "이 순간 기록하기" 버튼
         binding.createMomentButton.setOnClickListener {
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.container, CreateMomentFragment())
-                .addToBackStack(null)
-                .commit()
+            navigateToCreateMoment()
         }
+
+        // 빈 화면 카드 내의 "+" 아이콘
+        // (기존 코드에서는 AddPracticeModal이었으나, UI상 '기록'이 없을 때 뜨는 카드이므로 기록 화면으로 이동이 자연스러움)
         binding.addRecordIcon.setOnClickListener {
-            AddPracticeModal().show(childFragmentManager, AddPracticeModal.TAG)
+            navigateToCreateMoment()
+        }
+    }
+
+    private fun navigateToCreateMoment() {
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.container, CreateMomentFragment()) // container ID 확인 필요
+            .addToBackStack(null)
+            .commit()
+    }
+
+
+    private fun updateRecordUi(records: List<DailyRecord>) {
+        // 최신순 정렬
+        val sortedRecords = records.reversed()
+
+        // 어댑터에 데이터 제출
+        momentAdapter.submitList(sortedRecords)
+
+        val hasRecords = sortedRecords.isNotEmpty()
+
+        binding.apply {
+            // 기록이 있으면 -> 캐러셀 보이기, 빈 카드 숨기기
+            // (hasRecords가 Boolean으로 정상 인식되므로 ! 연산자 오류도 사라집니다)
+            recordsCarousel.isVisible = hasRecords
+            recordsIndicator.isVisible = hasRecords
+            emptyRecordCard.isVisible = !hasRecords
+
+            // 버튼은 항상 보이게 (또는 기획에 따라 조정)
+            createMomentButton.isVisible = true
         }
     }
 
@@ -80,18 +126,9 @@ class PresentFragment : BaseFragment<FragmentPresentBinding>() {
                         greetingText.text = uiState.userProfile.greeting
                         greetingPrompt.text = uiState.userProfile.prompt
                         practicesLeftBadge.text = "${uiState.practicesLeft}개 남음"
+
+                        // Practice 리스트 갱신
                         practiceAdapter.submitList(uiState.practices)
-
-                        // CreateMomentViewModel에서 저장된 기록들을 가져옴
-                        val savedRecords = CreateMomentViewModel.getSavedRecords()
-                        val hasRecords = savedRecords.isNotEmpty()
-                        emptyRecordCard.isVisible = !hasRecords
-                        recordsCarousel.isVisible = hasRecords
-                        recordsIndicator.isVisible = hasRecords
-
-                        if (hasRecords) {
-                            recordAdapter.submitList(savedRecords)
-                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/myapplication/feature/present/PresentUiState.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/PresentUiState.kt
@@ -24,6 +24,7 @@ data class DailyRecord(
     val photoUri: String, // 사진 URI 또는 파일 경로
     val memo: String = "", // 한 줄 메모 (빈 값 허용)
     val score: Int, // 1 ~ 10
+    val cesMetrics: CesMetrics,
     val meaning: Meaning = Meaning.REMEMBER, // 기억 or 잊기
     val date: String = "", // 날짜 (yyyy-MM-dd)
     val isFeatured: Boolean = false // 오늘의 대표 기억 여부

--- a/app/src/main/java/com/example/myapplication/feature/present/RecordAdapter.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/RecordAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.myapplication.R
 import com.example.myapplication.core.util.ImageUtils
 import com.example.myapplication.databinding.ItemRecordBinding
+import java.util.Locale
 
 class RecordAdapter : ListAdapter<DailyRecord, RecordAdapter.RecordViewHolder>(RecordDiffCallback()) {
 
@@ -26,8 +27,7 @@ class RecordAdapter : ListAdapter<DailyRecord, RecordAdapter.RecordViewHolder>(R
             // 메모 표시
             binding.recordMemo.text = if (record.memo.isNotEmpty()) record.memo else "(메모 없음)"
 
-            // 점수 표시
-            binding.recordScoreBadge.text = String.format("⭐ %d", record.score)
+            binding.recordCesValue.text = String.format(Locale.getDefault(), "%.1f", record.cesMetrics.weightedScore)
 
             // 날짜 표시
             binding.recordDate.text = record.date

--- a/app/src/main/res/drawable/gradient_shadow_bottom.xml
+++ b/app/src/main/res/drawable/gradient_shadow_bottom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="90"
+        android:endColor="#00000000"
+        android:startColor="#80000000"
+        android:type="linear" />
+</shape>

--- a/app/src/main/res/layout/fragment_add_goal.xml
+++ b/app/src/main/res/layout/fragment_add_goal.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/goal_edit_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="Enter your goal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/add_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Add"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/goal_edit_text" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_create_moment.xml
+++ b/app/src/main/res/layout/fragment_create_moment.xml
@@ -302,6 +302,161 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- ===== CES Inputs ===== -->
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/ces_card"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                app:cardBackgroundColor="@color/surface"
+                app:cardCornerRadius="16dp"
+                app:strokeColor="@color/border_divider"
+                app:strokeWidth="1dp"
+                app:layout_constraintTop_toBottomOf="@id/score_helper_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:id="@+id/ces_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="CES 점수 입력"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/identity_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="Identity (정체성 부합도)" />
+
+                    <TextView
+                        android:id="@+id/identity_question"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="이 사건은 ‘나’를 설명할 때 빠질 수 없는 핵심적인 내용인가?"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="12sp" />
+
+                    <TextView
+                        android:id="@+id/identity_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textColor="@color/secondary_accent"
+                        android:textStyle="bold"
+                        tools:text="3" />
+
+                    <com.google.android.material.slider.Slider
+                        android:id="@+id/identity_slider"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:valueFrom="1"
+                        android:valueTo="5"
+                        android:stepSize="1"
+                        android:value="3" />
+
+                    <TextView
+                        android:id="@+id/connectivity_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="Connectivity (기억 연결성)" />
+
+                    <TextView
+                        android:id="@+id/connectivity_question"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="다른 생각이나 행동 중에도 이 사건이 자주 떠오르는가?"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="12sp" />
+
+                    <TextView
+                        android:id="@+id/connectivity_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textColor="@color/secondary_accent"
+                        android:textStyle="bold"
+                        tools:text="3" />
+
+                    <com.google.android.material.slider.Slider
+                        android:id="@+id/connectivity_slider"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:valueFrom="1"
+                        android:valueTo="5"
+                        android:stepSize="1"
+                        android:value="3" />
+
+                    <TextView
+                        android:id="@+id/perspective_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="Perspective (판단 준거성)" />
+
+                    <TextView
+                        android:id="@+id/perspective_question"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="이 사건 이후 나의 가치관이나 행동 원칙이 바뀌었는가?"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="12sp" />
+
+                    <TextView
+                        android:id="@+id/perspective_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textColor="@color/secondary_accent"
+                        android:textStyle="bold"
+                        tools:text="3" />
+
+                    <com.google.android.material.slider.Slider
+                        android:id="@+id/perspective_slider"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:valueFrom="1"
+                        android:valueTo="5"
+                        android:stepSize="1"
+                        android:value="3" />
+
+                    <TextView
+                        android:id="@+id/ces_score_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="CES 점수" />
+
+                    <TextView
+                        android:id="@+id/ces_score_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/secondary_accent"
+                        android:textStyle="bold"
+                        tools:text="3.0" />
+
+                    <TextView
+                        android:id="@+id/ces_score_description"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="12sp"
+                        tools:text="보통" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <!-- 🚫 Meaning Section 제거됨 -->
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_create_moment.xml
+++ b/app/src/main/res/layout/fragment_create_moment.xml
@@ -176,22 +176,43 @@
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal">
-                        <TextView
-                            android:id="@+id/identity_label"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <LinearLayout
                             android:layout_width="0dp"
-                            android:layout_weight="1"
                             android:layout_height="wrap_content"
-                            android:text="Identity (정체성)"
-                            android:textStyle="bold" />
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:id="@+id/identity_label"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Identity (정체성)"
+                                android:textColor="@color/text_primary"
+                                android:textSize="14sp"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="4dp"
+                                android:text="얼마나 '나'다운 기억이었나요?"
+                                android:textColor="@color/text_secondary"
+                                android:textSize="12sp" />
+                        </LinearLayout>
+
                         <TextView
                             android:id="@+id/identity_value"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="1"
                             android:textColor="@color/secondary_accent"
+                            android:textSize="16sp"
                             android:textStyle="bold"/>
                     </LinearLayout>
+
                     <com.google.android.material.slider.Slider
                         android:id="@+id/identity_slider"
                         android:layout_width="match_parent"
@@ -205,22 +226,43 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
-                        android:layout_marginTop="8dp">
-                        <TextView
-                            android:id="@+id/connectivity_label"
+                        android:gravity="center_vertical"
+                        android:layout_marginTop="16dp">
+
+                        <LinearLayout
                             android:layout_width="0dp"
-                            android:layout_weight="1"
                             android:layout_height="wrap_content"
-                            android:text="Connectivity (연결성)"
-                            android:textStyle="bold" />
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:id="@+id/connectivity_label"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Connectivity (연결성)"
+                                android:textColor="@color/text_primary"
+                                android:textSize="14sp"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="4dp"
+                                android:text="무의식적으로 떠오를 것 같은 기억인가요?"
+                                android:textColor="@color/text_secondary"
+                                android:textSize="12sp" />
+                        </LinearLayout>
+
                         <TextView
                             android:id="@+id/connectivity_value"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="1"
                             android:textColor="@color/secondary_accent"
+                            android:textSize="16sp"
                             android:textStyle="bold"/>
                     </LinearLayout>
+
                     <com.google.android.material.slider.Slider
                         android:id="@+id/connectivity_slider"
                         android:layout_width="match_parent"
@@ -234,22 +276,43 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
-                        android:layout_marginTop="8dp">
-                        <TextView
-                            android:id="@+id/perspective_label"
+                        android:gravity="center_vertical"
+                        android:layout_marginTop="16dp">
+
+                        <LinearLayout
                             android:layout_width="0dp"
-                            android:layout_weight="1"
                             android:layout_height="wrap_content"
-                            android:text="Perspective (관점)"
-                            android:textStyle="bold" />
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:id="@+id/perspective_label"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Perspective (관점)"
+                                android:textColor="@color/text_primary"
+                                android:textSize="14sp"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="4dp"
+                                android:text="이 기억이 내일이나 앞날의 당신을 변화시킬 수 있나요?"
+                                android:textColor="@color/text_secondary"
+                                android:textSize="12sp" />
+                        </LinearLayout>
+
                         <TextView
                             android:id="@+id/perspective_value"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="1"
                             android:textColor="@color/secondary_accent"
+                            android:textSize="16sp"
                             android:textStyle="bold"/>
                     </LinearLayout>
+
                     <com.google.android.material.slider.Slider
                         android:id="@+id/perspective_slider"
                         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_create_moment.xml
+++ b/app/src/main/res/layout/fragment_create_moment.xml
@@ -147,51 +147,160 @@
                     android:hint="짧은 메모를 작성해보세요…" />
             </com.google.android.material.textfield.TextInputLayout>
 
-            <!-- ===== Score ===== -->
+            <!-- ===== CES Inputs ===== -->
 
-            <TextView
-                android:id="@+id/score_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:text="오늘의 점수"
-                app:layout_constraintTop_toBottomOf="@id/memo_input_layout"
-                app:layout_constraintStart_toStartOf="parent" />
-
-            <TextView
-                android:id="@+id/score_value"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/secondary_accent"
-                android:textSize="16sp"
-                android:textStyle="bold"
-                tools:text="5"
-                app:layout_constraintTop_toTopOf="@id/score_label"
-                app:layout_constraintBottom_toBottomOf="@id/score_label"
-                app:layout_constraintEnd_toEndOf="parent" />
-
-            <com.google.android.material.slider.Slider
-                android:id="@+id/score_slider"
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/ces_card"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:valueFrom="1"
-                android:valueTo="10"
-                android:stepSize="1"
-                android:value="5"
-                app:layout_constraintTop_toBottomOf="@id/score_label"
+                android:layout_marginTop="24dp"
+                app:cardBackgroundColor="@color/surface"
+                app:cardCornerRadius="16dp"
+                app:strokeColor="@color/border_divider"
+                app:strokeWidth="1dp"
+                app:layout_constraintTop_toBottomOf="@id/memo_input_layout"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent">
 
-            <TextView
-                android:id="@+id/score_helper_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="오늘의 만족도를 숫자로 남겨요."
-                android:textColor="@color/text_secondary"
-                android:textSize="12sp"
-                app:layout_constraintTop_toBottomOf="@id/score_slider"
-                app:layout_constraintStart_toStartOf="parent" />
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:id="@+id/ces_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="CES 점수 입력"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/identity_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="Identity (정체성 부합도)" />
+
+                    <TextView
+                        android:id="@+id/identity_question"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="이 사건은 ‘나’를 설명할 때 빠질 수 없는 핵심적인 내용인가?"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="12sp" />
+
+                    <TextView
+                        android:id="@+id/identity_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textColor="@color/secondary_accent"
+                        android:textStyle="bold"
+                        tools:text="3" />
+
+                    <com.google.android.material.slider.Slider
+                        android:id="@+id/identity_slider"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:valueFrom="1"
+                        android:valueTo="5"
+                        android:stepSize="1"
+                        android:value="3" />
+
+                    <TextView
+                        android:id="@+id/connectivity_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="Connectivity (기억 연결성)" />
+
+                    <TextView
+                        android:id="@+id/connectivity_question"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="다른 생각이나 행동 중에도 이 사건이 자주 떠오르는가?"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="12sp" />
+
+                    <TextView
+                        android:id="@+id/connectivity_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textColor="@color/secondary_accent"
+                        android:textStyle="bold"
+                        tools:text="3" />
+
+                    <com.google.android.material.slider.Slider
+                        android:id="@+id/connectivity_slider"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:valueFrom="1"
+                        android:valueTo="5"
+                        android:stepSize="1"
+                        android:value="3" />
+
+                    <TextView
+                        android:id="@+id/perspective_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="Perspective (판단 준거성)" />
+
+                    <TextView
+                        android:id="@+id/perspective_question"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="이 사건 이후 나의 가치관이나 행동 원칙이 바뀌었는가?"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="12sp" />
+
+                    <TextView
+                        android:id="@+id/perspective_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textColor="@color/secondary_accent"
+                        android:textStyle="bold"
+                        tools:text="3" />
+
+                    <com.google.android.material.slider.Slider
+                        android:id="@+id/perspective_slider"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:valueFrom="1"
+                        android:valueTo="5"
+                        android:stepSize="1"
+                        android:value="3" />
+
+                    <TextView
+                        android:id="@+id/ces_score_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="CES 점수" />
+
+                    <TextView
+                        android:id="@+id/ces_score_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/secondary_accent"
+                        android:textStyle="bold"
+                        tools:text="3.0" />
+
+                    <TextView
+                        android:id="@+id/ces_score_description"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="12sp"
+                        tools:text="보통" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
 
             <!-- 🚫 Meaning Section 제거됨 -->
 

--- a/app/src/main/res/layout/fragment_create_moment.xml
+++ b/app/src/main/res/layout/fragment_create_moment.xml
@@ -6,8 +6,6 @@
     android:layout_height="match_parent"
     android:background="@color/background">
 
-    <!-- ===== AppBar ===== -->
-
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
@@ -23,8 +21,6 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <!-- ===== Content ===== -->
-
     <androidx.core.widget.NestedScrollView
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -38,8 +34,6 @@
             android:layout_height="wrap_content"
             android:padding="16dp">
 
-            <!-- ===== Photo Area ===== -->
-
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/photo_card"
                 android:layout_width="0dp"
@@ -52,21 +46,26 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent">
 
-                <ImageView
-                    android:id="@+id/photo_preview"
+                <FrameLayout
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:scaleType="centerCrop" />
+                    android:layout_height="match_parent">
 
-                <TextView
-                    android:id="@+id/photo_placeholder"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:drawableTop="@android:drawable/ic_menu_camera"
-                    android:drawablePadding="8dp"
-                    android:text="사진을 추가해주세요" />
+                    <ImageView
+                        android:id="@+id/photo_preview"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:scaleType="centerCrop"
+                        tools:ignore="ContentDescription" />
 
+                    <TextView
+                        android:id="@+id/photo_placeholder"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:drawableTop="@android:drawable/ic_menu_camera"
+                        android:drawablePadding="8dp"
+                        android:text="사진을 추가해주세요" />
+                </FrameLayout>
             </com.google.android.material.card.MaterialCardView>
 
             <LinearLayout
@@ -95,10 +94,7 @@
                     android:layout_height="wrap_content"
                     android:backgroundTint="@color/surface"
                     android:text="갤러리" />
-
             </LinearLayout>
-
-            <!-- ===== Featured ===== -->
 
             <CheckBox
                 android:id="@+id/featured_checkbox"
@@ -118,8 +114,6 @@
                 android:textSize="12sp"
                 app:layout_constraintTop_toBottomOf="@id/featured_checkbox"
                 app:layout_constraintStart_toStartOf="@id/featured_checkbox" />
-
-            <!-- ===== Memo ===== -->
 
             <TextView
                 android:id="@+id/memo_label"
@@ -147,173 +141,29 @@
                     android:hint="짧은 메모를 작성해보세요…" />
             </com.google.android.material.textfield.TextInputLayout>
 
-            <!-- ===== CES Inputs ===== -->
 
-            <com.google.android.material.card.MaterialCardView
-                android:id="@+id/ces_card"
-                android:layout_width="0dp"
+            <TextView
+                android:id="@+id/ces_label"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                app:cardBackgroundColor="@color/surface"
-                app:cardCornerRadius="16dp"
-                app:strokeColor="@color/border_divider"
-                app:strokeWidth="1dp"
+                android:layout_marginTop="32dp"
+                android:text="CES 지수 측정"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:textColor="@color/text_primary"
                 app:layout_constraintTop_toBottomOf="@id/memo_input_layout"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent">
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="16dp">
-
-                    <TextView
-                        android:id="@+id/ces_title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="CES 점수 입력"
-                        android:textStyle="bold" />
-
-                    <TextView
-                        android:id="@+id/identity_label"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:text="Identity (정체성 부합도)" />
-
-                    <TextView
-                        android:id="@+id/identity_question"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="이 사건은 ‘나’를 설명할 때 빠질 수 없는 핵심적인 내용인가?"
-                        android:textColor="@color/text_secondary"
-                        android:textSize="12sp" />
-
-                    <TextView
-                        android:id="@+id/identity_value"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="4dp"
-                        android:textColor="@color/secondary_accent"
-                        android:textStyle="bold"
-                        tools:text="3" />
-
-                    <com.google.android.material.slider.Slider
-                        android:id="@+id/identity_slider"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
-                        android:valueFrom="1"
-                        android:valueTo="5"
-                        android:stepSize="1"
-                        android:value="3" />
-
-                    <TextView
-                        android:id="@+id/connectivity_label"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:text="Connectivity (기억 연결성)" />
-
-                    <TextView
-                        android:id="@+id/connectivity_question"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="다른 생각이나 행동 중에도 이 사건이 자주 떠오르는가?"
-                        android:textColor="@color/text_secondary"
-                        android:textSize="12sp" />
-
-                    <TextView
-                        android:id="@+id/connectivity_value"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="4dp"
-                        android:textColor="@color/secondary_accent"
-                        android:textStyle="bold"
-                        tools:text="3" />
-
-                    <com.google.android.material.slider.Slider
-                        android:id="@+id/connectivity_slider"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
-                        android:valueFrom="1"
-                        android:valueTo="5"
-                        android:stepSize="1"
-                        android:value="3" />
-
-                    <TextView
-                        android:id="@+id/perspective_label"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:text="Perspective (판단 준거성)" />
-
-                    <TextView
-                        android:id="@+id/perspective_question"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="이 사건 이후 나의 가치관이나 행동 원칙이 바뀌었는가?"
-                        android:textColor="@color/text_secondary"
-                        android:textSize="12sp" />
-
-                    <TextView
-                        android:id="@+id/perspective_value"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="4dp"
-                        android:textColor="@color/secondary_accent"
-                        android:textStyle="bold"
-                        tools:text="3" />
-
-                    <com.google.android.material.slider.Slider
-                        android:id="@+id/perspective_slider"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
-                        android:valueFrom="1"
-                        android:valueTo="5"
-                        android:stepSize="1"
-                        android:value="3" />
-
-                    <TextView
-                        android:id="@+id/ces_score_label"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:text="CES 점수" />
-
-                    <TextView
-                        android:id="@+id/ces_score_value"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textColor="@color/secondary_accent"
-                        android:textStyle="bold"
-                        tools:text="3.0" />
-
-                    <TextView
-                        android:id="@+id/ces_score_description"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textColor="@color/text_secondary"
-                        android:textSize="12sp"
-                        tools:text="보통" />
-                </LinearLayout>
-            </com.google.android.material.card.MaterialCardView>
-
-            <!-- ===== CES Inputs ===== -->
+                app:layout_constraintStart_toStartOf="parent" />
 
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/ces_card"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
+                android:layout_marginTop="12dp"
                 app:cardBackgroundColor="@color/surface"
                 app:cardCornerRadius="16dp"
                 app:strokeColor="@color/border_divider"
                 app:strokeWidth="1dp"
-                app:layout_constraintTop_toBottomOf="@id/score_helper_text"
+                app:layout_constraintTop_toBottomOf="@id/ces_label"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent">
 
@@ -321,149 +171,140 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:padding="16dp">
+                    android:padding="20dp">
 
-                    <TextView
-                        android:id="@+id/ces_title"
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="CES 점수 입력"
-                        android:textStyle="bold" />
-
-                    <TextView
-                        android:id="@+id/identity_label"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:text="Identity (정체성 부합도)" />
-
-                    <TextView
-                        android:id="@+id/identity_question"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="이 사건은 ‘나’를 설명할 때 빠질 수 없는 핵심적인 내용인가?"
-                        android:textColor="@color/text_secondary"
-                        android:textSize="12sp" />
-
-                    <TextView
-                        android:id="@+id/identity_value"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="4dp"
-                        android:textColor="@color/secondary_accent"
-                        android:textStyle="bold"
-                        tools:text="3" />
-
+                        android:orientation="horizontal">
+                        <TextView
+                            android:id="@+id/identity_label"
+                            android:layout_width="0dp"
+                            android:layout_weight="1"
+                            android:layout_height="wrap_content"
+                            android:text="Identity (정체성)"
+                            android:textStyle="bold" />
+                        <TextView
+                            android:id="@+id/identity_value"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="1"
+                            android:textColor="@color/secondary_accent"
+                            android:textStyle="bold"/>
+                    </LinearLayout>
                     <com.google.android.material.slider.Slider
                         android:id="@+id/identity_slider"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
                         android:valueFrom="1"
                         android:valueTo="5"
                         android:stepSize="1"
-                        android:value="3" />
+                        android:value="1"/>
 
-                    <TextView
-                        android:id="@+id/connectivity_label"
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:text="Connectivity (기억 연결성)" />
-
-                    <TextView
-                        android:id="@+id/connectivity_question"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="다른 생각이나 행동 중에도 이 사건이 자주 떠오르는가?"
-                        android:textColor="@color/text_secondary"
-                        android:textSize="12sp" />
-
-                    <TextView
-                        android:id="@+id/connectivity_value"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="4dp"
-                        android:textColor="@color/secondary_accent"
-                        android:textStyle="bold"
-                        tools:text="3" />
-
+                        android:orientation="horizontal"
+                        android:layout_marginTop="8dp">
+                        <TextView
+                            android:id="@+id/connectivity_label"
+                            android:layout_width="0dp"
+                            android:layout_weight="1"
+                            android:layout_height="wrap_content"
+                            android:text="Connectivity (연결성)"
+                            android:textStyle="bold" />
+                        <TextView
+                            android:id="@+id/connectivity_value"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="1"
+                            android:textColor="@color/secondary_accent"
+                            android:textStyle="bold"/>
+                    </LinearLayout>
                     <com.google.android.material.slider.Slider
                         android:id="@+id/connectivity_slider"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
                         android:valueFrom="1"
                         android:valueTo="5"
                         android:stepSize="1"
-                        android:value="3" />
+                        android:value="1"/>
 
-                    <TextView
-                        android:id="@+id/perspective_label"
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:text="Perspective (판단 준거성)" />
-
-                    <TextView
-                        android:id="@+id/perspective_question"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="이 사건 이후 나의 가치관이나 행동 원칙이 바뀌었는가?"
-                        android:textColor="@color/text_secondary"
-                        android:textSize="12sp" />
-
-                    <TextView
-                        android:id="@+id/perspective_value"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="4dp"
-                        android:textColor="@color/secondary_accent"
-                        android:textStyle="bold"
-                        tools:text="3" />
-
+                        android:orientation="horizontal"
+                        android:layout_marginTop="8dp">
+                        <TextView
+                            android:id="@+id/perspective_label"
+                            android:layout_width="0dp"
+                            android:layout_weight="1"
+                            android:layout_height="wrap_content"
+                            android:text="Perspective (관점)"
+                            android:textStyle="bold" />
+                        <TextView
+                            android:id="@+id/perspective_value"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="1"
+                            android:textColor="@color/secondary_accent"
+                            android:textStyle="bold"/>
+                    </LinearLayout>
                     <com.google.android.material.slider.Slider
                         android:id="@+id/perspective_slider"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
                         android:valueFrom="1"
                         android:valueTo="5"
                         android:stepSize="1"
-                        android:value="3" />
+                        android:value="1"/>
 
-                    <TextView
-                        android:id="@+id/ces_score_label"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:text="CES 점수" />
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginTop="8dp"
+                        android:layout_marginBottom="16dp"
+                        android:background="@color/border_divider"/>
 
-                    <TextView
-                        android:id="@+id/ces_score_value"
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:textColor="@color/secondary_accent"
-                        android:textStyle="bold"
-                        tools:text="3.0" />
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
 
-                    <TextView
-                        android:id="@+id/ces_score_description"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textColor="@color/text_secondary"
-                        android:textSize="12sp"
-                        tools:text="보통" />
+                        <TextView
+                            android:id="@+id/ces_score_label"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="종합 CES 점수"
+                            android:textStyle="bold"
+                            android:textSize="16sp"/>
+
+                        <View android:layout_width="0dp" android:layout_weight="1" android:layout_height="0dp"/>
+
+                        <TextView
+                            android:id="@+id/ces_score_value"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="0점"
+                            android:textSize="18sp"
+                            android:textColor="@color/secondary_accent"
+                            android:textStyle="bold"/>
+
+                        <TextView
+                            android:id="@+id/ces_score_description"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="(낮음)"
+                            android:textColor="@color/text_secondary"
+                            android:textSize="14sp"/>
+                    </LinearLayout>
+
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
-
-            <!-- 🚫 Meaning Section 제거됨 -->
-
         </androidx.constraintlayout.widget.ConstraintLayout>
-
     </androidx.core.widget.NestedScrollView>
-
-    <!-- ===== Save Button ===== -->
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/save_moment_button"

--- a/app/src/main/res/layout/fragment_present.xml
+++ b/app/src/main/res/layout/fragment_present.xml
@@ -186,7 +186,7 @@
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/records_carousel"
             android:layout_width="match_parent"
-            android:layout_height="220dp"
+            android:layout_height="320dp"
             android:layout_marginTop="16dp"
             app:layout_constraintTop_toBottomOf="@id/create_moment_button" />
 

--- a/app/src/main/res/layout/item_moment_card.xml
+++ b/app/src/main/res/layout/item_moment_card.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginHorizontal="8dp"
+    android:layout_marginBottom="8dp"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="4dp"
+    app:cardBackgroundColor="@color/surface">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/iv_moment_photo"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_gallery"
+            app:layout_constraintHeight_percent="0.65"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@drawable/gradient_shadow_bottom"
+            app:layout_constraintBottom_toBottomOf="@id/iv_moment_photo"
+            app:layout_constraintHeight_percent="0.2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:padding="16dp"
+            app:layout_constraintTop_toBottomOf="@id/iv_moment_photo"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <TextView
+                android:id="@+id/tv_ces_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="CES 점수"
+                android:textSize="12sp"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_ces_score"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="6dp"
+                android:text="8.5"
+                android:textStyle="bold"
+                android:textSize="18sp"
+                android:textColor="@color/secondary_accent"
+                app:layout_constraintStart_toEndOf="@id/tv_ces_label"
+                app:layout_constraintBaseline_toBaselineOf="@id/tv_ces_label" />
+
+            <View
+                android:id="@+id/divider"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginTop="8dp"
+                android:background="@color/border_divider"
+                app:layout_constraintTop_toBottomOf="@id/tv_ces_score" />
+
+            <TextView
+                android:id="@+id/tv_memo"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginTop="8dp"
+                android:text="오늘 하루도 정말 고생 많았다. 내일도 화이팅!"
+                android:textColor="@color/text_primary"
+                android:textSize="14sp"
+                android:ellipsize="end"
+                android:maxLines="3"
+                app:layout_constraintTop_toBottomOf="@id/divider"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_record.xml
+++ b/app/src/main/res/layout/item_record.xml
@@ -12,73 +12,46 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <!-- Photo -->
         <ImageView
             android:id="@+id/record_photo"
             android:layout_width="0dp"
-            android:layout_height="0dp"
+            android:layout_height="200dp"
             android:scaleType="centerCrop"
-            app:layout_constraintBottom_toTopOf="@+id/record_memo"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             tools:srcCompat="@tools:sample/backgrounds/scenic" />
 
+        <!-- Date badge -->
         <TextView
             android:id="@+id/record_date"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:layout_marginStart="8dp"
+            android:layout_margin="8dp"
             android:background="@drawable/badge_background"
-            android:paddingStart="8dp"
-            android:paddingTop="4dp"
-            android:paddingEnd="8dp"
-            android:paddingBottom="4dp"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="4dp"
             android:textColor="@color/badge_text"
             android:textSize="12sp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="2025-01-10" />
 
+        <!-- Meaning badge -->
         <TextView
             android:id="@+id/meaning_badge"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            android:paddingStart="8dp"
-            android:paddingTop="4dp"
-            android:paddingEnd="8dp"
-            android:paddingBottom="4dp"
+            android:layout_margin="8dp"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="4dp"
             android:textSize="12sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="✅ 기억" />
 
-        <TextView
-            android:id="@+id/record_ces_label"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
-            android:layout_marginStart="8dp"
-            android:text="CES"
-            android:textColor="@color/text_secondary"
-            android:textSize="12sp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toTopOf="@+id/record_memo" />
-
-        <TextView
-            android:id="@+id/record_ces_value"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
-            android:layout_marginBottom="8dp"
-            android:textColor="@color/text_secondary"
-            android:textSize="12sp"
-            app:layout_constraintStart_toEndOf="@id/record_ces_label"
-            app:layout_constraintBottom_toTopOf="@+id/record_memo"
-            tools:text="3.5" />
-
+        <!-- Memo -->
         <TextView
             android:id="@+id/record_memo"
             android:layout_width="0dp"
@@ -86,10 +59,35 @@
             android:padding="12dp"
             android:textColor="@color/text_primary"
             android:textSize="14sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/record_photo"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             tools:text="오늘 하루 정말 보람찼다!" />
+
+        <!-- CES label -->
+        <TextView
+            android:id="@+id/record_ces_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="4dp"
+            android:text="CES"
+            android:textColor="@color/text_secondary"
+            android:textSize="12sp"
+            app:layout_constraintTop_toBottomOf="@id/record_memo"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <!-- CES value -->
+        <TextView
+            android:id="@+id/record_ces_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:textColor="@color/text_secondary"
+            android:textSize="12sp"
+            app:layout_constraintStart_toEndOf="@id/record_ces_label"
+            app:layout_constraintBaseline_toBaselineOf="@id/record_ces_label"
+            tools:text="3.5" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/item_record.xml
+++ b/app/src/main/res/layout/item_record.xml
@@ -56,21 +56,28 @@
             tools:text="✅ 기억" />
 
         <TextView
-            android:id="@+id/record_score_badge"
+            android:id="@+id/record_ces_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
-            android:layout_marginEnd="8dp"
-            android:background="@drawable/badge_background"
-            android:paddingStart="8dp"
-            android:paddingTop="4dp"
-            android:paddingEnd="8dp"
-            android:paddingBottom="4dp"
-            android:textColor="@color/badge_text"
+            android:layout_marginStart="8dp"
+            android:text="CES"
+            android:textColor="@color/text_secondary"
             android:textSize="12sp"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/record_memo" />
+
+        <TextView
+            android:id="@+id/record_ces_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginBottom="8dp"
+            android:textColor="@color/text_secondary"
+            android:textSize="12sp"
+            app:layout_constraintStart_toEndOf="@id/record_ces_label"
             app:layout_constraintBottom_toTopOf="@+id/record_memo"
-            tools:text="⭐ 5" />
+            tools:text="3.5" />
 
         <TextView
             android:id="@+id/record_memo"


### PR DESCRIPTION
### Motivation
- Introduce CES (Identity, Connectivity, Perspective) scoring to the Present/Record flow so users can provide CES ratings when creating a moment.
- Compute CES weighted score in the ViewModel using the specified weights (wI=0.5, wC=0.2, wP=0.3) and show results in the UI in real time.
- Enforce that CES input/editing is only allowed in the `PRESENT` time state and keep past records read-only.
- Prepare an extensible boundary for future highlight logic by adding an outlier-analysis interface for CES (to be used when N > 30).

### Description
- Added `CesModels.kt` with `CesInput`, `CesMetrics`, `CesOutlierAnalyzer` and `CesOutlierResult` to model CES data and provide an outlier analysis interface.
- Added `TimeState` enum in `core.util` and extended `CreateMomentUiState` with `cesInput`, `cesWeightedScore`, `cesDescription`, and `timeState` to store CES and state.
- Implemented CES handling in `CreateMomentViewModel` with `setCesIdentity`, `setCesConnectivity`, `setCesPerspective`, `calculateCesScore`, `describeCesScore`, `buildCesMetrics`, and present-only checks, and persist `cesMetrics` on `DailyRecord` when saving.
- Updated `fragment_create_moment.xml` and `CreateMomentFragment` to add three sliders and related labels for I/C/P, show numeric `cesScore` and `cesDescription`, and wire real-time updates from the ViewModel, including enabling inputs only when `timeState == PRESENT`.

### Testing
- No automated tests were executed as part of this change (no test run requested).
- Manual runtime verification was not recorded in automated form (UI wiring added for live observation of `cesWeightedScore`).
- Static compilation/build was not performed within this rollout (no build/test logs produced).
- Future work: add unit tests for `calculateCesScore` and integration tests for `TimeState` enforcement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69645f518848832e8cda85e369279216)