### PR TITLE
Add edit option for today's moment card

### DIFF
--- a/app/src/main/java/com/example/myapplication/feature/present/CreateMomentFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/CreateMomentFragment.kt
@@ -15,6 +15,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import androidx.core.os.bundleOf
 import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -91,6 +92,10 @@ class CreateMomentFragment : BaseFragment<FragmentCreateMomentBinding>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        arguments?.getString(ARG_EDIT_RECORD_ID)?.let { recordId ->
+            viewModel.startEdit(recordId)
+        }
 
         setupToolbar()
         setupCesSliders() // CES 슬라이더 설정으로 변경
@@ -272,6 +277,11 @@ class CreateMomentFragment : BaseFragment<FragmentCreateMomentBinding>() {
                     binding.connectivityValue.text = state.cesInput.connectivity.toString()
                     binding.perspectiveValue.text = state.cesInput.perspective.toString()
 
+                    if (binding.memoEditText.text?.toString() != state.memo) {
+                        binding.memoEditText.setText(state.memo)
+                        binding.memoEditText.setSelection(state.memo.length)
+                    }
+
                     binding.cesScoreValue.text = "${state.cesWeightedScore}점"
                     binding.cesScoreDescription.text = state.cesDescription
 
@@ -332,5 +342,15 @@ class CreateMomentFragment : BaseFragment<FragmentCreateMomentBinding>() {
                 viewModel.confirmFeaturedReplacement(false)
             }
             .show()
+    }
+
+    companion object {
+        private const val ARG_EDIT_RECORD_ID = "arg_edit_record_id"
+
+        fun newInstance(recordId: String): CreateMomentFragment {
+            return CreateMomentFragment().apply {
+                arguments = bundleOf(ARG_EDIT_RECORD_ID to recordId)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/myapplication/feature/present/CreateMomentUiState.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/CreateMomentUiState.kt
@@ -27,5 +27,6 @@ data class CreateMomentUiState(
     val allowFeaturedReplacement: Boolean = false,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
-    val savedSuccessfully: Boolean = false
+    val savedSuccessfully: Boolean = false,
+    val editMode: Boolean = false
 )

--- a/app/src/main/java/com/example/myapplication/feature/present/MomentAdapter.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/MomentAdapter.kt
@@ -3,13 +3,18 @@ package com.example.myapplication.feature.present
 import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.example.myapplication.databinding.ItemMomentCardBinding
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 // ❌ 삭제됨: data class DailyRecord(...)
 // (이제 DailyModels.kt에 있는 클래스를 자동으로 가져다 씁니다)
 
 class MomentAdapter(
+    private val onEditClick: ((DailyRecord) -> Unit)? = null,
     private var items: List<DailyRecord> = emptyList()
 ) : RecyclerView.Adapter<MomentAdapter.MomentViewHolder>() {
 
@@ -30,6 +35,15 @@ class MomentAdapter(
 
             // 3. 메모 설정
             binding.tvMemo.text = if (record.memo.isNotBlank()) record.memo else "메모가 없습니다."
+
+            val isEditableToday = isToday(record.date)
+            binding.editMomentButton.isVisible = isEditableToday
+            binding.editMomentButton.setOnClickListener(null)
+            if (isEditableToday) {
+                binding.editMomentButton.setOnClickListener {
+                    onEditClick?.invoke(record)
+                }
+            }
         }
     }
 
@@ -51,5 +65,13 @@ class MomentAdapter(
     fun submitList(newItems: List<DailyRecord>) {
         items = newItems
         notifyDataSetChanged()
+    }
+
+    private fun isToday(date: String): Boolean {
+        if (date.isBlank()) {
+            return false
+        }
+        val today = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
+        return date == today
     }
 }

--- a/app/src/main/java/com/example/myapplication/feature/present/PresentFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/PresentFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -63,7 +64,9 @@ class PresentFragment : BaseFragment<FragmentPresentBinding>() {
         binding.practicesRecyclerView.adapter = practiceAdapter
 
         // 2. Moment Carousel (ViewPager2) - 변경됨
-        momentAdapter = MomentAdapter()
+        momentAdapter = MomentAdapter { record ->
+            showEditMomentDialog(record)
+        }
         binding.recordsCarousel.apply {
             adapter = momentAdapter
             offscreenPageLimit = 1 // 양옆의 카드를 미리 로드하여 부드럽게
@@ -94,6 +97,38 @@ class PresentFragment : BaseFragment<FragmentPresentBinding>() {
             .replace(R.id.container, CreateMomentFragment()) // container ID 확인 필요
             .addToBackStack(null)
             .commit()
+    }
+
+    private fun navigateToEditMoment(record: DailyRecord) {
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.container, CreateMomentFragment.newInstance(record.id)) // container ID 확인 필요
+            .addToBackStack(null)
+            .commit()
+    }
+
+    private fun showEditMomentDialog(record: DailyRecord) {
+        if (!record.isToday()) {
+            return
+        }
+
+        AlertDialog.Builder(requireContext())
+            .setMessage("오늘의 기억을 수정하시겠습니까?\n오늘만 수정이 가능합니다.")
+            .setNegativeButton("취소") { dialog, _ ->
+                dialog.dismiss()
+            }
+            .setPositiveButton("수정") { _, _ ->
+                navigateToEditMoment(record)
+            }
+            .show()
+    }
+
+    private fun DailyRecord.isToday(): Boolean {
+        if (date.isBlank()) {
+            return false
+        }
+        val today = java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.getDefault())
+            .format(java.util.Date())
+        return date == today
     }
 
 

--- a/app/src/main/res/layout/item_moment_card.xml
+++ b/app/src/main/res/layout/item_moment_card.xml
@@ -25,6 +25,19 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
+        <ImageButton
+            android:id="@+id/edit_moment_button"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_margin="12dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/edit_moment"
+            android:padding="4dp"
+            android:src="@android:drawable/ic_menu_edit"
+            android:tint="@color/surface"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <View
             android:layout_width="match_parent"
             android:layout_height="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="past_tab_placeholder">과거 탭입니다</string>
     <string name="highlight_tab_placeholder">하이라이트 탭 (준비 중)</string>
     <string name="future_tab_placeholder">미래 탭입니다</string>
+    <string name="edit_moment">오늘의 기억 수정</string>
 </resources>


### PR DESCRIPTION
### Motivation
- Allow users to edit a moment recorded for today by adding an edit affordance on the moment card and an edit flow into the existing CreateMoment screen.
- Ensure the edit control is only visible for records whose `date` equals today and that edits are permitted only in the `PRESENT` time state.
- Reuse existing MVVM structure so edits prefill the CreateMoment UI and preserve existing record fields where appropriate.

### Description
- Added an edit `ImageButton` to the moment card layout and string resource via `item_moment_card.xml` and `strings.xml`.
- Updated `MomentAdapter` to show the edit button only for today's record and to forward an `onEditClick` callback to the host via `MomentAdapter(onEditClick)`.
- Implemented an edit confirmation `AlertDialog` and navigation to edit mode in `PresentFragment`, and added `CreateMomentFragment.newInstance(recordId)` to pass the edit id.
- Extended `CreateMomentUiState` with `editMode` and added `startEdit`, editing state tracking, and update logic in `CreateMomentViewModel` to prefill UI and update the in-memory `savedRecords` instead of always creating a new record.

### Testing
- No automated tests were run for this change.
- Changes were kept minimal to avoid affecting existing save logic and state validations, and the `TimeState` guard remains in `CreateMomentViewModel` to prevent editing non-present records.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a93e615c832eaa38e5b023d6b8a9)