### PR TITLE
Add Highlight tab (Polarity Analysis) and integrate edit flow for today's moment

### DIFF
--- a/app/src/main/java/com/example/myapplication/feature/highlight/FakeRecordRepository.kt
+++ b/app/src/main/java/com/example/myapplication/feature/highlight/FakeRecordRepository.kt
@@ -1,0 +1,17 @@
+package com.example.myapplication.feature.highlight
+
+import com.example.myapplication.feature.present.CreateMomentViewModel
+import com.example.myapplication.feature.present.DailyRecord
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class FakeRecordRepository : RecordRepository {
+
+    override fun getTodayRecords(): List<DailyRecord> {
+        val today = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
+        // TODO: Replace with Room/JSON-backed repository that filters records by date.
+        return CreateMomentViewModel.getSavedRecords()
+            .filter { it.date == today }
+    }
+}

--- a/app/src/main/java/com/example/myapplication/feature/highlight/HighlightFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/highlight/HighlightFragment.kt
@@ -1,24 +1,159 @@
 package com.example.myapplication.feature.highlight
 
+import android.content.res.Resources
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.example.myapplication.R
 import com.example.myapplication.core.base.BaseFragment
-import com.example.myapplication.databinding.FragmentSimplePlaceholderBinding
+import com.example.myapplication.databinding.FragmentHighlightBinding
+import com.example.myapplication.databinding.ItemHighlightSectionBinding
+import com.example.myapplication.feature.present.CreateMomentViewModel
+import kotlinx.coroutines.launch
 
-class HighlightFragment : BaseFragment<FragmentSimplePlaceholderBinding>() {
+class HighlightFragment : BaseFragment<FragmentHighlightBinding>() {
+
+    private val viewModel: HighlightViewModel by activityViewModels()
 
     override fun inflateBinding(
         inflater: LayoutInflater,
         container: ViewGroup?
-    ): FragmentSimplePlaceholderBinding {
-        return FragmentSimplePlaceholderBinding.inflate(inflater, container, false)
+    ): FragmentHighlightBinding {
+        return FragmentHighlightBinding.inflate(inflater, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.placeholderText.setText(R.string.highlight_tab_placeholder)
+        observeUiState()
+        refreshData()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refreshData()
+    }
+
+    private fun refreshData() {
+        val records = CreateMomentViewModel.getSavedRecords()
+        viewModel.refreshIfNeeded(records)
+    }
+
+    private fun observeUiState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    val sections = state.sections
+                    val hasSections = sections.isNotEmpty()
+                    binding.highlightEmptyCard.isVisible = !hasSections
+
+                    bindSection(
+                        binding.sectionMasterpiece,
+                        sections.firstOrNull { it.type == HighlightType.MASTERPIECE }
+                    )
+                    bindSection(
+                        binding.sectionHiddenDriver,
+                        sections.firstOrNull { it.type == HighlightType.HIDDEN_DRIVER }
+                    )
+                    bindSection(
+                        binding.sectionEmotionalAnchor,
+                        sections.firstOrNull { it.type == HighlightType.EMOTIONAL_ANCHOR }
+                    )
+
+                    emphasizeTopScore(sections)
+                }
+            }
+        }
+    }
+
+    private fun bindSection(
+        sectionBinding: ItemHighlightSectionBinding,
+        section: HighlightSection?
+    ) {
+        val primary = section?.primary
+        sectionBinding.root.isVisible = primary != null
+        if (primary == null || section == null) {
+            return
+        }
+
+        sectionBinding.highlightTitle.text = section.title
+        sectionBinding.highlightDescription.text = section.description
+        sectionBinding.highlightMemo.text =
+            if (primary.memo.isNotBlank()) primary.memo else "메모가 없습니다."
+        sectionBinding.highlightScoreValue.text =
+            "${primary.identityScore} / ${primary.connectivityScore} / ${primary.perspectiveScore}"
+
+        if (primary.photoUri.isNotBlank()) {
+            sectionBinding.highlightPhoto.setImageURI(android.net.Uri.parse(primary.photoUri))
+        } else {
+            sectionBinding.highlightPhoto.setImageResource(android.R.drawable.ic_menu_gallery)
+        }
+
+        sectionBinding.highlightCard.setOnClickListener {
+            navigateToPresent(primary.recordId)
+        }
+
+        // TODO: secondary 후보를 보여주는 디자인과 상호작용을 추가하세요.
+        val accentColor = when (section.type) {
+            HighlightType.MASTERPIECE -> R.color.primary
+            HighlightType.HIDDEN_DRIVER -> R.color.secondary_accent
+            HighlightType.EMOTIONAL_ANCHOR -> R.color.error
+        }
+        sectionBinding.highlightAccent.setBackgroundColor(requireContext().getColor(accentColor))
+
+        val totalScore = primary.identityScore + primary.connectivityScore + primary.perspectiveScore
+        sectionBinding.highlightCard.tag = totalScore
+        applyPhotoHeight(sectionBinding, totalScore)
+    }
+
+    private fun emphasizeTopScore(sections: List<HighlightSection>) {
+        val primaryItems = sections.mapNotNull { it.primary }
+        val topScore = primaryItems.maxOfOrNull {
+            it.identityScore + it.connectivityScore + it.perspectiveScore
+        } ?: return
+
+        val bindings = listOf(
+            binding.sectionMasterpiece,
+            binding.sectionHiddenDriver,
+            binding.sectionEmotionalAnchor
+        )
+        for (sectionBinding in bindings) {
+            val totalScore = sectionBinding.highlightCard.tag as? Int
+            val isTop = totalScore == topScore
+            sectionBinding.highlightCard.strokeWidth =
+                if (isTop) dpToPx(2) else dpToPx(1)
+            sectionBinding.highlightCard.cardElevation =
+                if (isTop) dpToPx(6).toFloat() else dpToPx(4).toFloat()
+        }
+    }
+
+    private fun applyPhotoHeight(
+        sectionBinding: ItemHighlightSectionBinding,
+        score: Int
+    ) {
+        val minHeight = 160
+        val maxHeight = 240
+        val normalized = ((score - 3).coerceIn(0, 12)).toFloat() / 12f
+        val heightDp = (minHeight + (maxHeight - minHeight) * normalized).toInt()
+        val params = sectionBinding.highlightPhoto.layoutParams
+        params.height = dpToPx(heightDp)
+        sectionBinding.highlightPhoto.layoutParams = params
+    }
+
+    private fun navigateToPresent(recordId: String) {
+        val bottomNavigation = requireActivity().findViewById<com.google.android.material.bottomnavigation.BottomNavigationView>(
+            R.id.bottomNavigation
+        )
+        bottomNavigation.selectedItemId = R.id.navigation_present
+        // TODO: PresentFragment와 연결하여 recordId로 스크롤 이동을 지원하세요.
+    }
+
+    private fun dpToPx(dp: Int): Int {
+        return (dp * Resources.getSystem().displayMetrics.density).toInt()
     }
 }

--- a/app/src/main/java/com/example/myapplication/feature/highlight/HighlightModels.kt
+++ b/app/src/main/java/com/example/myapplication/feature/highlight/HighlightModels.kt
@@ -1,31 +1,25 @@
 package com.example.myapplication.feature.highlight
 
-enum class HighlightType {
-    MASTERPIECE,
-    HIDDEN_DRIVER,
-    EMOTIONAL_ANCHOR
+enum class HighlightMetric(val title: String) {
+    IDENTITY("나다운 기억 TOP 5"),
+    CONNECTIVITY("무의식의 나 TOP 5"),
+    PERSPECTIVE("가장 큰 영향을 준 기억 TOP 5")
 }
 
-data class HighlightItem(
-    val type: HighlightType,
-    val title: String,
-    val description: String,
+data class HighlightRankItem(
+    val recordId: String,
+    val rank: Int,
     val photoUri: String,
     val memo: String,
-    val identityScore: Int,
-    val connectivityScore: Int,
-    val perspectiveScore: Int,
-    val recordId: String
+    val score: Int
 )
 
-data class HighlightSection(
-    val type: HighlightType,
-    val title: String,
-    val description: String,
-    val primary: HighlightItem?,
-    val secondary: List<HighlightItem> = emptyList()
+data class HighlightRankSection(
+    val metric: HighlightMetric,
+    val items: List<HighlightRankItem>
 )
 
 data class HighlightUiState(
-    val sections: List<HighlightSection> = emptyList()
+    val sections: List<HighlightRankSection> = emptyList(),
+    val showEmptyState: Boolean = true
 )

--- a/app/src/main/java/com/example/myapplication/feature/highlight/HighlightModels.kt
+++ b/app/src/main/java/com/example/myapplication/feature/highlight/HighlightModels.kt
@@ -1,0 +1,31 @@
+package com.example.myapplication.feature.highlight
+
+enum class HighlightType {
+    MASTERPIECE,
+    HIDDEN_DRIVER,
+    EMOTIONAL_ANCHOR
+}
+
+data class HighlightItem(
+    val type: HighlightType,
+    val title: String,
+    val description: String,
+    val photoUri: String,
+    val memo: String,
+    val identityScore: Int,
+    val connectivityScore: Int,
+    val perspectiveScore: Int,
+    val recordId: String
+)
+
+data class HighlightSection(
+    val type: HighlightType,
+    val title: String,
+    val description: String,
+    val primary: HighlightItem?,
+    val secondary: List<HighlightItem> = emptyList()
+)
+
+data class HighlightUiState(
+    val sections: List<HighlightSection> = emptyList()
+)

--- a/app/src/main/java/com/example/myapplication/feature/highlight/HighlightRankAdapter.kt
+++ b/app/src/main/java/com/example/myapplication/feature/highlight/HighlightRankAdapter.kt
@@ -1,0 +1,53 @@
+package com.example.myapplication.feature.highlight
+
+import android.net.Uri
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.myapplication.databinding.ItemHighlightRankBinding
+
+class HighlightRankAdapter(
+    private val onItemClick: (HighlightRankItem) -> Unit
+) : RecyclerView.Adapter<HighlightRankAdapter.RankViewHolder>() {
+
+    private var items: List<HighlightRankItem> = emptyList()
+
+    inner class RankViewHolder(private val binding: ItemHighlightRankBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: HighlightRankItem) {
+            binding.rankNumber.text = item.rank.toString()
+            binding.rankMemo.text = if (item.memo.isNotBlank()) item.memo else "메모가 없습니다."
+            binding.rankScore.text = item.score.toString()
+
+            if (item.photoUri.isNotBlank()) {
+                binding.rankPhoto.setImageURI(Uri.parse(item.photoUri))
+            } else {
+                binding.rankPhoto.setImageResource(android.R.drawable.ic_menu_gallery)
+            }
+
+            binding.root.setOnClickListener {
+                onItemClick(item)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RankViewHolder {
+        val binding = ItemHighlightRankBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return RankViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: RankViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun submitList(newItems: List<HighlightRankItem>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/java/com/example/myapplication/feature/highlight/HighlightViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/feature/highlight/HighlightViewModel.kt
@@ -1,0 +1,154 @@
+package com.example.myapplication.feature.highlight
+
+import androidx.lifecycle.ViewModel
+import com.example.myapplication.feature.present.DailyRecord
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class HighlightViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HighlightUiState())
+    val uiState: StateFlow<HighlightUiState> = _uiState.asStateFlow()
+
+    private var lastRecordSignature: List<String> = emptyList()
+
+    fun refreshIfNeeded(records: List<DailyRecord>) {
+        val signature = records.map { record ->
+            listOf(
+                record.id,
+                record.photoUri,
+                record.memo,
+                record.cesMetrics.identity,
+                record.cesMetrics.connectivity,
+                record.cesMetrics.perspective,
+                record.date,
+                record.isFeatured
+            ).joinToString("|")
+        }
+        if (signature == lastRecordSignature) {
+            return
+        }
+        lastRecordSignature = signature
+        _uiState.value = HighlightUiState(
+            sections = buildSections(records)
+        )
+    }
+
+    private fun buildSections(records: List<DailyRecord>): List<HighlightSection> {
+        val masterpiece = buildSection(
+            type = HighlightType.MASTERPIECE,
+            title = "나다운 기억",
+            description = "I·C·P가 모두 높은 기억이에요.",
+            candidates = records.filter { isMasterpiece(it) }
+        )
+        val hiddenDriver = buildSection(
+            type = HighlightType.HIDDEN_DRIVER,
+            title = "무의식의 나",
+            description = "I가 낮고 P가 높은 기억이에요.",
+            candidates = records.filter { isHiddenDriver(it) }
+        )
+        val emotionalAnchor = buildSection(
+            type = HighlightType.EMOTIONAL_ANCHOR,
+            title = "가장 큰 영향",
+            description = "C가 다른 지표보다 크게 높은 기억이에요.",
+            candidates = records.filter { isEmotionalAnchor(it) }
+        )
+
+        return listOf(masterpiece, hiddenDriver, emotionalAnchor)
+            .filter { it.primary != null }
+    }
+
+    private fun buildSection(
+        type: HighlightType,
+        title: String,
+        description: String,
+        candidates: List<DailyRecord>
+    ): HighlightSection {
+        if (candidates.isEmpty()) {
+            return HighlightSection(type, title, description, primary = null)
+        }
+
+        val scoredCandidates = candidates.map { record ->
+            record to totalScore(record)
+        }
+        val maxScore = scoredCandidates.maxOf { it.second }
+        val topCandidates = scoredCandidates.filter { it.second == maxScore }.map { it.first }
+        val primaryRecord = topCandidates.maxByOrNull { record -> parseDate(record.date) } ?: topCandidates.first()
+        val secondary = scoredCandidates
+            .map { it.first }
+            .filter { it.id != primaryRecord.id }
+            .sortedWith(
+                compareByDescending<DailyRecord> { totalScore(it) }
+                    .thenByDescending { parseDate(it.date) }
+            )
+            .take(3)
+            .map { toHighlightItem(type, title, description, it) }
+
+        return HighlightSection(
+            type = type,
+            title = title,
+            description = description,
+            primary = toHighlightItem(type, title, description, primaryRecord),
+            secondary = secondary
+        )
+    }
+
+    private fun toHighlightItem(
+        type: HighlightType,
+        title: String,
+        description: String,
+        record: DailyRecord
+    ): HighlightItem {
+        return HighlightItem(
+            type = type,
+            title = title,
+            description = description,
+            photoUri = record.photoUri,
+            memo = record.memo,
+            identityScore = record.cesMetrics.identity,
+            connectivityScore = record.cesMetrics.connectivity,
+            perspectiveScore = record.cesMetrics.perspective,
+            recordId = record.id
+        )
+    }
+
+    private fun isMasterpiece(record: DailyRecord): Boolean {
+        return record.cesMetrics.identity >= HIGH_THRESHOLD &&
+            record.cesMetrics.connectivity >= HIGH_THRESHOLD &&
+            record.cesMetrics.perspective >= HIGH_THRESHOLD
+    }
+
+    private fun isHiddenDriver(record: DailyRecord): Boolean {
+        return record.cesMetrics.identity <= LOW_THRESHOLD &&
+            record.cesMetrics.perspective >= HIGH_THRESHOLD
+    }
+
+    private fun isEmotionalAnchor(record: DailyRecord): Boolean {
+        val maxOther = maxOf(record.cesMetrics.identity, record.cesMetrics.perspective)
+        return record.cesMetrics.connectivity >= HIGH_THRESHOLD &&
+            record.cesMetrics.connectivity - maxOther >= ANCHOR_DELTA
+    }
+
+    private fun totalScore(record: DailyRecord): Int {
+        return record.cesMetrics.identity + record.cesMetrics.connectivity + record.cesMetrics.perspective
+    }
+
+    private fun parseDate(date: String): Long {
+        return try {
+            val format = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            format.parse(date)?.time ?: 0L
+        } catch (e: ParseException) {
+            0L
+        }
+    }
+
+    companion object {
+        private const val HIGH_THRESHOLD = 4
+        private const val LOW_THRESHOLD = 2
+        private const val ANCHOR_DELTA = 2
+    }
+}

--- a/app/src/main/java/com/example/myapplication/feature/highlight/RecordRepository.kt
+++ b/app/src/main/java/com/example/myapplication/feature/highlight/RecordRepository.kt
@@ -1,0 +1,7 @@
+package com.example.myapplication.feature.highlight
+
+import com.example.myapplication.feature.present.DailyRecord
+
+interface RecordRepository {
+    fun getTodayRecords(): List<DailyRecord>
+}

--- a/app/src/main/java/com/example/myapplication/feature/present/CreateMomentFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/CreateMomentFragment.kt
@@ -15,6 +15,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import androidx.core.os.bundleOf
 import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -91,6 +92,10 @@ class CreateMomentFragment : BaseFragment<FragmentCreateMomentBinding>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        arguments?.getString(ARG_EDIT_RECORD_ID)?.let { recordId ->
+            viewModel.startEdit(recordId)
+        }
 
         setupToolbar()
         setupCesSliders() // CES 슬라이더 설정으로 변경
@@ -272,6 +277,11 @@ class CreateMomentFragment : BaseFragment<FragmentCreateMomentBinding>() {
                     binding.connectivityValue.text = state.cesInput.connectivity.toString()
                     binding.perspectiveValue.text = state.cesInput.perspective.toString()
 
+                    if (binding.memoEditText.text?.toString() != state.memo) {
+                        binding.memoEditText.setText(state.memo)
+                        binding.memoEditText.setSelection(state.memo.length)
+                    }
+
                     binding.cesScoreValue.text = "${state.cesWeightedScore}점"
                     binding.cesScoreDescription.text = state.cesDescription
 
@@ -332,5 +342,15 @@ class CreateMomentFragment : BaseFragment<FragmentCreateMomentBinding>() {
                 viewModel.confirmFeaturedReplacement(false)
             }
             .show()
+    }
+
+    companion object {
+        private const val ARG_EDIT_RECORD_ID = "arg_edit_record_id"
+
+        fun newInstance(recordId: String): CreateMomentFragment {
+            return CreateMomentFragment().apply {
+                arguments = bundleOf(ARG_EDIT_RECORD_ID to recordId)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/myapplication/feature/present/CreateMomentUiState.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/CreateMomentUiState.kt
@@ -27,5 +27,6 @@ data class CreateMomentUiState(
     val allowFeaturedReplacement: Boolean = false,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
-    val savedSuccessfully: Boolean = false
+    val savedSuccessfully: Boolean = false,
+    val editMode: Boolean = false
 )

--- a/app/src/main/java/com/example/myapplication/feature/present/MomentAdapter.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/MomentAdapter.kt
@@ -14,10 +14,22 @@ import java.util.Locale
 // (이제 DailyModels.kt에 있는 클래스를 자동으로 가져다 씁니다)
 
 class MomentAdapter(
-    private val onEditClick: ((DailyRecord) -> Unit)? = null,
-    private var items: List<DailyRecord> = emptyList()
+    private val onEditClick: ((DailyRecord) -> Unit)? = null
 ) : RecyclerView.Adapter<MomentAdapter.MomentViewHolder>() {
 
+    private var items: List<DailyRecord> = emptyList()
+
+
+    fun setItems(newItems: List<DailyRecord>) {
+        items = newItems
+        notifyDataSetChanged()
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: MomentViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
     inner class MomentViewHolder(private val binding: ItemMomentCardBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
@@ -55,12 +67,6 @@ class MomentAdapter(
         )
         return MomentViewHolder(binding)
     }
-
-    override fun onBindViewHolder(holder: MomentViewHolder, position: Int) {
-        holder.bind(items[position])
-    }
-
-    override fun getItemCount(): Int = items.size
 
     fun submitList(newItems: List<DailyRecord>) {
         items = newItems

--- a/app/src/main/java/com/example/myapplication/feature/present/MomentAdapter.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/MomentAdapter.kt
@@ -3,13 +3,18 @@ package com.example.myapplication.feature.present
 import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.example.myapplication.databinding.ItemMomentCardBinding
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 // ❌ 삭제됨: data class DailyRecord(...)
 // (이제 DailyModels.kt에 있는 클래스를 자동으로 가져다 씁니다)
 
 class MomentAdapter(
+    private val onEditClick: ((DailyRecord) -> Unit)? = null,
     private var items: List<DailyRecord> = emptyList()
 ) : RecyclerView.Adapter<MomentAdapter.MomentViewHolder>() {
 
@@ -30,6 +35,15 @@ class MomentAdapter(
 
             // 3. 메모 설정
             binding.tvMemo.text = if (record.memo.isNotBlank()) record.memo else "메모가 없습니다."
+
+            val isEditableToday = isToday(record.date)
+            binding.editMomentButton.isVisible = isEditableToday
+            binding.editMomentButton.setOnClickListener(null)
+            if (isEditableToday) {
+                binding.editMomentButton.setOnClickListener {
+                    onEditClick?.invoke(record)
+                }
+            }
         }
     }
 
@@ -51,5 +65,13 @@ class MomentAdapter(
     fun submitList(newItems: List<DailyRecord>) {
         items = newItems
         notifyDataSetChanged()
+    }
+
+    private fun isToday(date: String): Boolean {
+        if (date.isBlank()) {
+            return false
+        }
+        val today = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
+        return date == today
     }
 }

--- a/app/src/main/java/com/example/myapplication/feature/present/PresentFragment.kt
+++ b/app/src/main/java/com/example/myapplication/feature/present/PresentFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -63,7 +64,9 @@ class PresentFragment : BaseFragment<FragmentPresentBinding>() {
         binding.practicesRecyclerView.adapter = practiceAdapter
 
         // 2. Moment Carousel (ViewPager2) - 변경됨
-        momentAdapter = MomentAdapter()
+        momentAdapter = MomentAdapter { record ->
+            showEditMomentDialog(record)
+        }
         binding.recordsCarousel.apply {
             adapter = momentAdapter
             offscreenPageLimit = 1 // 양옆의 카드를 미리 로드하여 부드럽게
@@ -94,6 +97,38 @@ class PresentFragment : BaseFragment<FragmentPresentBinding>() {
             .replace(R.id.container, CreateMomentFragment()) // container ID 확인 필요
             .addToBackStack(null)
             .commit()
+    }
+
+    private fun navigateToEditMoment(record: DailyRecord) {
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.container, CreateMomentFragment.newInstance(record.id)) // container ID 확인 필요
+            .addToBackStack(null)
+            .commit()
+    }
+
+    private fun showEditMomentDialog(record: DailyRecord) {
+        if (!record.isToday()) {
+            return
+        }
+
+        AlertDialog.Builder(requireContext())
+            .setMessage("오늘의 기억을 수정하시겠습니까?\n오늘만 수정이 가능합니다.")
+            .setNegativeButton("취소") { dialog, _ ->
+                dialog.dismiss()
+            }
+            .setPositiveButton("수정") { _, _ ->
+                navigateToEditMoment(record)
+            }
+            .show()
+    }
+
+    private fun DailyRecord.isToday(): Boolean {
+        if (date.isBlank()) {
+            return false
+        }
+        val today = java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.getDefault())
+            .format(java.util.Date())
+        return date == today
     }
 
 

--- a/app/src/main/res/drawable/bg_edit_circle.xml
+++ b/app/src/main/res/drawable/bg_edit_circle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <solid android:color="#66000000" />
+</shape>

--- a/app/src/main/res/drawable/rank_number_background.xml
+++ b/app/src/main/res/drawable/rank_number_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/badge_background" />
+</shape>

--- a/app/src/main/res/layout/fragment_highlight.xml
+++ b/app/src/main/res/layout/fragment_highlight.xml
@@ -44,16 +44,17 @@
                     android:textSize="14sp" />
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- TODO: ranking 섹션 디자인을 polish 할 수 있도록 여백과 색을 조정하세요. -->
             <include
-                android:id="@+id/section_masterpiece"
+                android:id="@+id/section_identity"
                 layout="@layout/item_highlight_section" />
 
             <include
-                android:id="@+id/section_hidden_driver"
+                android:id="@+id/section_connectivity"
                 layout="@layout/item_highlight_section" />
 
             <include
-                android:id="@+id/section_emotional_anchor"
+                android:id="@+id/section_perspective"
                 layout="@layout/item_highlight_section" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_highlight.xml
+++ b/app/src/main/res/layout/fragment_highlight.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background"
+    tools:context="com.example.myapplication.feature.highlight.HighlightFragment">
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/highlight_scroll"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/highlight_empty_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                app:cardBackgroundColor="@color/surface"
+                app:cardCornerRadius="16dp"
+                app:cardElevation="2dp"
+                app:strokeColor="@color/border_divider"
+                app:strokeWidth="1dp">
+
+                <TextView
+                    android:id="@+id/highlight_empty_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="20dp"
+                    android:text="@string/highlight_empty_state"
+                    android:textAlignment="center"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="14sp" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <include
+                android:id="@+id/section_masterpiece"
+                layout="@layout/item_highlight_section" />
+
+            <include
+                android:id="@+id/section_hidden_driver"
+                layout="@layout/item_highlight_section" />
+
+            <include
+                android:id="@+id/section_emotional_anchor"
+                layout="@layout/item_highlight_section" />
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_highlight_rank.xml
+++ b/app/src/main/res/layout/item_highlight_rank.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/rank_item_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="12dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/rank_number"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:gravity="center"
+        android:textColor="@color/text_primary"
+        android:textStyle="bold"
+        android:textSize="14sp"
+        android:background="@drawable/rank_number_background"
+        android:text="1" />
+
+    <ImageView
+        android:id="@+id/rank_photo"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:layout_marginStart="12dp"
+        android:scaleType="centerCrop"
+        android:src="@android:drawable/ic_menu_gallery"
+        android:contentDescription="@string/highlight_rank_photo" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/rank_memo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/text_primary"
+            android:maxLines="2"
+            android:ellipsize="end"
+            android:textSize="13sp"
+            android:text="메모 내용" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/rank_score"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/secondary_accent"
+        android:textStyle="bold"
+        android:textSize="14sp"
+        android:text="5" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_highlight_section.xml
+++ b/app/src/main/res/layout/item_highlight_section.xml
@@ -2,7 +2,7 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/highlight_card"
+    android:id="@+id/section_card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="16dp"
@@ -15,84 +15,25 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:padding="16dp">
 
-        <View
-            android:id="@+id/highlight_accent"
-            android:layout_width="match_parent"
-            android:layout_height="6dp"
-            android:background="@color/primary" />
+        <TextView
+            android:id="@+id/section_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textColor="@color/text_primary"
+            android:textStyle="bold"
+            tools:text="나다운 기억 TOP 5" />
 
-        <LinearLayout
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/section_list"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp">
-
-            <TextView
-                android:id="@+id/highlight_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textAppearance="?attr/textAppearanceTitleMedium"
-                android:textColor="@color/text_primary"
-                android:textStyle="bold"
-                tools:text="나다운 기억" />
-
-            <TextView
-                android:id="@+id/highlight_description"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:textAppearance="?attr/textAppearanceBodySmall"
-                android:textColor="@color/text_secondary"
-                tools:text="I·C·P가 모두 높은 기억이에요." />
-
-            <ImageView
-                android:id="@+id/highlight_photo"
-                android:layout_width="match_parent"
-                android:layout_height="180dp"
-                android:layout_marginTop="12dp"
-                android:scaleType="centerCrop"
-                android:src="@android:drawable/ic_menu_gallery"
-                tools:ignore="ContentDescription" />
-
-            <TextView
-                android:id="@+id/highlight_memo"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:textColor="@color/text_primary"
-                android:textSize="14sp"
-                android:maxLines="3"
-                android:ellipsize="end"
-                tools:text="오늘의 기억을 짧게 요약합니다." />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:id="@+id/highlight_score_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/highlight_score_label"
-                    android:textColor="@color/text_secondary"
-                    android:textSize="12sp" />
-
-                <TextView
-                    android:id="@+id/highlight_score_value"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:textColor="@color/text_primary"
-                    android:textStyle="bold"
-                    android:textSize="14sp"
-                    tools:text="4 / 5 / 3" />
-            </LinearLayout>
-
-        </LinearLayout>
+            android:layout_marginTop="12dp"
+            android:overScrollMode="never"
+            tools:listitem="@layout/item_highlight_rank" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/item_highlight_section.xml
+++ b/app/src/main/res/layout/item_highlight_section.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/highlight_card"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    app:cardBackgroundColor="@color/surface"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="4dp"
+    app:strokeColor="@color/border_divider"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <View
+            android:id="@+id/highlight_accent"
+            android:layout_width="match_parent"
+            android:layout_height="6dp"
+            android:background="@color/primary" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/highlight_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceTitleMedium"
+                android:textColor="@color/text_primary"
+                android:textStyle="bold"
+                tools:text="나다운 기억" />
+
+            <TextView
+                android:id="@+id/highlight_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textAppearance="?attr/textAppearanceBodySmall"
+                android:textColor="@color/text_secondary"
+                tools:text="I·C·P가 모두 높은 기억이에요." />
+
+            <ImageView
+                android:id="@+id/highlight_photo"
+                android:layout_width="match_parent"
+                android:layout_height="180dp"
+                android:layout_marginTop="12dp"
+                android:scaleType="centerCrop"
+                android:src="@android:drawable/ic_menu_gallery"
+                tools:ignore="ContentDescription" />
+
+            <TextView
+                android:id="@+id/highlight_memo"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:textColor="@color/text_primary"
+                android:textSize="14sp"
+                android:maxLines="3"
+                android:ellipsize="end"
+                tools:text="오늘의 기억을 짧게 요약합니다." />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/highlight_score_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/highlight_score_label"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="12sp" />
+
+                <TextView
+                    android:id="@+id/highlight_score_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:textColor="@color/text_primary"
+                    android:textStyle="bold"
+                    android:textSize="14sp"
+                    tools:text="4 / 5 / 3" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_moment_card.xml
+++ b/app/src/main/res/layout/item_moment_card.xml
@@ -25,6 +25,19 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
+        <ImageButton
+            android:id="@+id/edit_moment_button"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_margin="12dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/edit_moment"
+            android:padding="4dp"
+            android:src="@android:drawable/ic_menu_edit"
+            android:tint="@color/surface"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <View
             android:layout_width="match_parent"
             android:layout_height="0dp"

--- a/app/src/main/res/layout/item_moment_card.xml
+++ b/app/src/main/res/layout/item_moment_card.xml
@@ -27,16 +27,16 @@
 
         <ImageButton
             android:id="@+id/edit_moment_button"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
             android:layout_margin="12dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/edit_moment"
-            android:padding="4dp"
+            android:background="@drawable/bg_edit_circle"
             android:src="@android:drawable/ic_menu_edit"
-            android:tint="@color/surface"
+            android:tint="@android:color/white"
+            android:elevation="6dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
 
         <View
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="past_tab_placeholder">과거 탭입니다</string>
     <string name="highlight_tab_placeholder">하이라이트 탭 (준비 중)</string>
     <string name="future_tab_placeholder">미래 탭입니다</string>
+    <string name="edit_moment">오늘의 기억 수정</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="edit_moment">오늘의 기억 수정</string>
     <string name="highlight_empty_state">아직 분석할 기억이 충분하지 않아요.</string>
     <string name="highlight_score_label">I / C / P</string>
+    <string name="highlight_rank_photo">랭킹 사진</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,7 @@
     <string name="past_tab_placeholder">과거 탭입니다</string>
     <string name="highlight_tab_placeholder">하이라이트 탭 (준비 중)</string>
     <string name="future_tab_placeholder">미래 탭입니다</string>
+    <string name="edit_moment">오늘의 기억 수정</string>
+    <string name="highlight_empty_state">아직 분석할 기억이 충분하지 않아요.</string>
+    <string name="highlight_score_label">I / C / P</string>
 </resources>


### PR DESCRIPTION
### Motivation
- Provide a dedicated "Highlight" tab that surfaces polarity-based highlights (I/C/P) from saved moments so users can discover meaningful memories.
- Keep analysis logic in a ViewModel and reuse the existing in-memory record source to avoid duplicating storage logic.
- Allow quick navigation from a highlight back to the Present tab and enable editing of today's moment via the existing Create flow.
- Keep UI read-only for Highlight and expose TODOs for future UX polish (secondary candidates, scroll-to-record, etc.).

### Description
- Added highlight domain & UI models and state: `HighlightType`, `HighlightItem`, `HighlightSection`, and `HighlightUiState` in `feature/highlight/HighlightModels.kt`.
- Implemented polarity analysis logic and state management in `HighlightViewModel` with thresholds (`HIGH_THRESHOLD`, `LOW_THRESHOLD`, `ANCHOR_DELTA`) and `refreshIfNeeded(records: List<DailyRecord>)` to avoid unnecessary recomputation.
- Created a Highlight UI skeleton: `fragment_highlight.xml` and `item_highlight_section.xml`, and a bound fragment `HighlightFragment` that observes `HighlightViewModel` and renders sections (accent color, photo sizing by score, empty state) and navigates back to Present on tap.
- Integrated lightweight edit flow and Present wiring: added an edit button to `item_moment_card.xml` and `MomentAdapter` (shows button only for today), `PresentFragment` now shows an edit confirmation and navigates to `CreateMomentFragment.newInstance(recordId)`, and `CreateMomentFragment` / `CreateMomentViewModel` were extended to support editing (`startEdit`, `editingRecordId`, `updateRecord`, featured-record handling with exclusion).

### Testing
- No automated tests were run for these changes.
- (Notes) The implementation is intentionally minimal: UI contains TODO comments for secondary candidate UI and precise scroll-to-record integration, and analysis execution is guarded by `refreshIfNeeded` to avoid recomputing on tab switches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a93e615c832eaa38e5b023d6b8a9)